### PR TITLE
Added generics-based methods GetParameters/GetColumns

### DIFF
--- a/SLC-S-ProtocolExtension.sln
+++ b/SLC-S-ProtocolExtension.sln
@@ -11,6 +11,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Utils.Protocol.Extension.Tests", "Utils.Protocol.Extension.Tests\Utils.Protocol.Extension.Tests.csproj", "{0BC5A4C0-CE1A-FE01-7B2C-EEF4B59A247A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{591BB4B5-A2AD-451C-96E1-7610D094D193}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{591BB4B5-A2AD-451C-96E1-7610D094D193}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{591BB4B5-A2AD-451C-96E1-7610D094D193}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0BC5A4C0-CE1A-FE01-7B2C-EEF4B59A247A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0BC5A4C0-CE1A-FE01-7B2C-EEF4B59A247A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0BC5A4C0-CE1A-FE01-7B2C-EEF4B59A247A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0BC5A4C0-CE1A-FE01-7B2C-EEF4B59A247A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Utils.Protocol.Extension.Tests/ProtocolExtensionTests.cs
+++ b/Utils.Protocol.Extension.Tests/ProtocolExtensionTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace Skyline.DataMiner.Utils.Protocol.Extension.Tests
 {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
 

--- a/Utils.Protocol.Extension.Tests/ProtocolExtensionTests.cs
+++ b/Utils.Protocol.Extension.Tests/ProtocolExtensionTests.cs
@@ -1,19 +1,38 @@
 ﻿namespace Skyline.DataMiner.Utils.Protocol.Extension.Tests
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
-
-    using Skyline.DataMiner.Scripting;
 
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     using NSubstitute;
 
+    using Skyline.DataMiner.Scripting;
+
     [TestClass]
     public class ProtocolExtensionTests
     {
         private const int TableId = 1000;
+
+
+        [TestMethod]
+        public void GetColumns_T1T2TReturn_InvalidResult_ThrowsOnCallNotOnIteration_DemonstratesOldDeferredBehavior()
+        {
+            // Arrange
+            var protocol = Substitute.For<SLProtocol>();
+            var columnIndices = new uint[] { 0, 1 };
+
+            // NotifyProtocol returns null, which ValidateResult considers invalid.
+            protocol.NotifyProtocol(321, TableId, Arg.Any<object>()).Returns((object)null);
+
+            // It is only when iteration is triggered that ValidateResult runs and throws.
+            Assert.ThrowsException<InvalidOperationException>(() => protocol.GetColumns(
+                TableId,
+                columnIndices,
+                (string col0, string col1) => $"{col0}-{col1}"));
+        }
 
         [TestMethod]
         public void GetColumn_T_InvokesNotifyProtocol321WithCorrectTableIdAndColumnIdx()
@@ -21,25 +40,14 @@
             var protocol = Substitute.For<SLProtocol>();
             uint colIdx = 2;
             protocol.NotifyProtocol(321, TableId, Arg.Is<object>(o => ((uint[])o).SequenceEqual(new[] { colIdx })))
-                    .Returns(new object[] { new object[] { "1" } });
+                    .Returns(new object[] { new object[] { "10", "20", "30" } });
 
-            protocol.GetColumn<int>(TableId, colIdx).ToList();
+            var result = protocol.GetColumn<int>(TableId, colIdx).ToList();
 
             protocol.Received(1).NotifyProtocol(
                 321,
                 TableId,
                 Arg.Is<object>(o => ((uint[])o).SequenceEqual(new[] { colIdx })));
-        }
-
-        [TestMethod]
-        public void GetColumn_T_ReturnsValuesConvertedToRequestedType()
-        {
-            var protocol = Substitute.For<SLProtocol>();
-            uint colIdx = 0;
-            protocol.NotifyProtocol(321, TableId, Arg.Is<object>(o => ((uint[])o).SequenceEqual(new[] { colIdx })))
-                    .Returns(new object[] { new object[] { "10", "20", "30" } });
-
-            List<int> result = protocol.GetColumn<int>(TableId, colIdx).ToList();
 
             CollectionAssert.AreEqual(new[] { 10, 20, 30 }, result);
         }
@@ -77,22 +85,11 @@
             var protocol = Substitute.For<SLProtocol>();
             var indices = new uint[] { 0, 1 };
             protocol.NotifyProtocol(321, TableId, indices)
-                    .Returns(new object[] { new object[] { "key1" }, new object[] { "10" } });
-
-            protocol.GetColumns<string, int, string>(TableId, indices, (k, v) => $"{k}:{v}").ToList();
-
-            protocol.Received(1).NotifyProtocol(321, TableId, indices);
-        }
-
-        [TestMethod]
-        public void GetColumns_T2_ReturnsSelectorResultForEveryRow()
-        {
-            var protocol = Substitute.For<SLProtocol>();
-            var indices = new uint[] { 0, 1 };
-            protocol.NotifyProtocol(321, TableId, indices)
                     .Returns(new object[] { new object[] { "key1", "key2" }, new object[] { "10", "20" } });
 
             List<string> result = protocol.GetColumns<string, int, string>(TableId, indices, (k, v) => $"{k}:{v}").ToList();
+
+            protocol.Received(1).NotifyProtocol(321, TableId, indices);
 
             CollectionAssert.AreEqual(new[] { "key1:10", "key2:20" }, result);
         }
@@ -101,7 +98,7 @@
         public void GetColumns_T2_NullIndices_ThrowsArgumentNullException()
         {
             var protocol = Substitute.For<SLProtocol>();
-            Assert.ThrowsException<ArgumentNullException>(() => protocol.GetColumns<string, int, string>(TableId, null, (k, v) => string.Empty).ToList());
+            Assert.ThrowsException<ArgumentNullException>(() => protocol.GetColumns<string, int, string>(TableId, null, (k, v) => String.Empty).ToList());
         }
 
         [TestMethod]
@@ -115,20 +112,7 @@
         public void GetColumns_T2_WrongColumnCount_ThrowsArgumentOutOfRangeException()
         {
             var protocol = Substitute.For<SLProtocol>();
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => protocol.GetColumns<string, int, string>(TableId, new uint[] { 0 }, (k, v) => string.Empty).ToList());
-        }
-
-        [TestMethod]
-        public void GetColumns_T3_InvokesNotifyProtocol321WithCorrectArguments()
-        {
-            var protocol = Substitute.For<SLProtocol>();
-            var indices = new uint[] { 0, 1, 2 };
-            protocol.NotifyProtocol(321, TableId, indices)
-                    .Returns(new object[] { new object[] { "key1" }, new object[] { "10" }, new object[] { "true" } });
-
-            protocol.GetColumns<string, int, bool, string>(TableId, indices, (k, v, b) => $"{k}:{v}:{b}").ToList();
-
-            protocol.Received(1).NotifyProtocol(321, TableId, indices);
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => protocol.GetColumns<string, int, string>(TableId, new uint[] { 0 }, (k, v) => String.Empty).ToList());
         }
 
         [TestMethod]
@@ -141,6 +125,8 @@
 
             List<string> result = protocol.GetColumns<string, int, bool, string>(TableId, indices, (k, v, b) => $"{k}:{v}:{b}").ToList();
 
+            protocol.Received(1).NotifyProtocol(321, TableId, indices);
+
             CollectionAssert.AreEqual(new[] { "key1:10:True", "key2:20:False" }, result);
         }
 
@@ -148,7 +134,7 @@
         public void GetColumns_T3_NullIndices_ThrowsArgumentNullException()
         {
             var protocol = Substitute.For<SLProtocol>();
-            Assert.ThrowsException<ArgumentNullException>(() => protocol.GetColumns<string, int, bool, string>(TableId, null, (k, v, b) => string.Empty).ToList());
+            Assert.ThrowsException<ArgumentNullException>(() => protocol.GetColumns<string, int, bool, string>(TableId, null, (k, v, b) => String.Empty).ToList());
         }
 
         [TestMethod]
@@ -162,7 +148,7 @@
         public void GetColumns_T3_WrongColumnCount_ThrowsArgumentOutOfRangeException()
         {
             var protocol = Substitute.For<SLProtocol>();
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => protocol.GetColumns<string, int, bool, string>(TableId, new uint[] { 0, 1 }, (k, v, b) => string.Empty).ToList());
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => protocol.GetColumns<string, int, bool, string>(TableId, new uint[] { 0, 1 }, (k, v, b) => String.Empty).ToList());
         }
 
         [TestMethod]
@@ -173,29 +159,18 @@
             protocol.NotifyProtocol(321, TableId, indices)
                     .Returns(new object[] { new object[] { "k" }, new object[] { "1" }, new object[] { "2" }, new object[] { "3" } });
 
-            protocol.GetColumns<string, int, int, int, string>(TableId, indices, (a, b, c, d) => $"{a}:{b}:{c}:{d}").ToList();
-
-            protocol.Received(1).NotifyProtocol(321, TableId, indices);
-        }
-
-        [TestMethod]
-        public void GetColumns_T4_ReturnsSelectorResultForEveryRow()
-        {
-            var protocol = Substitute.For<SLProtocol>();
-            var indices = new uint[] { 0, 1, 2, 3 };
-            protocol.NotifyProtocol(321, TableId, indices)
-                    .Returns(new object[] { new object[] { "key1" }, new object[] { "1" }, new object[] { "2" }, new object[] { "3" } });
-
             List<string> result = protocol.GetColumns<string, int, int, int, string>(TableId, indices, (a, b, c, d) => $"{a}:{b}:{c}:{d}").ToList();
 
-            CollectionAssert.AreEqual(new[] { "key1:1:2:3" }, result);
+            protocol.Received(1).NotifyProtocol(321, TableId, indices);
+
+            CollectionAssert.AreEqual(new[] { "k:1:2:3" }, result);
         }
 
         [TestMethod]
         public void GetColumns_T4_NullIndices_ThrowsArgumentNullException()
         {
             var protocol = Substitute.For<SLProtocol>();
-            Assert.ThrowsException<ArgumentNullException>(() => protocol.GetColumns<string, int, int, int, string>(TableId, null, (a, b, c, d) => string.Empty).ToList());
+            Assert.ThrowsException<ArgumentNullException>(() => protocol.GetColumns<string, int, int, int, string>(TableId, null, (a, b, c, d) => String.Empty).ToList());
         }
 
         [TestMethod]
@@ -209,7 +184,7 @@
         public void GetColumns_T4_WrongColumnCount_ThrowsArgumentOutOfRangeException()
         {
             var protocol = Substitute.For<SLProtocol>();
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => protocol.GetColumns<string, int, int, int, string>(TableId, new uint[] { 0, 1, 2 }, (a, b, c, d) => string.Empty).ToList());
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => protocol.GetColumns<string, int, int, int, string>(TableId, new uint[] { 0, 1, 2 }, (a, b, c, d) => String.Empty).ToList());
         }
 
         [TestMethod]
@@ -220,29 +195,18 @@
             protocol.NotifyProtocol(321, TableId, indices)
                     .Returns(new object[] { new object[] { "k" }, new object[] { "1" }, new object[] { "2" }, new object[] { "3" }, new object[] { "4" } });
 
-            protocol.GetColumns<string, int, int, int, int, string>(TableId, indices, (a, b, c, d, e) => $"{a}:{b}:{c}:{d}:{e}").ToList();
-
-            protocol.Received(1).NotifyProtocol(321, TableId, indices);
-        }
-
-        [TestMethod]
-        public void GetColumns_T5_ReturnsSelectorResultForEveryRow()
-        {
-            var protocol = Substitute.For<SLProtocol>();
-            var indices = new uint[] { 0, 1, 2, 3, 4 };
-            protocol.NotifyProtocol(321, TableId, indices)
-                    .Returns(new object[] { new object[] { "key1" }, new object[] { "1" }, new object[] { "2" }, new object[] { "3" }, new object[] { "4" } });
-
             List<string> result = protocol.GetColumns<string, int, int, int, int, string>(TableId, indices, (a, b, c, d, e) => $"{a}:{b}:{c}:{d}:{e}").ToList();
 
-            CollectionAssert.AreEqual(new[] { "key1:1:2:3:4" }, result);
+            protocol.Received(1).NotifyProtocol(321, TableId, indices);
+
+            CollectionAssert.AreEqual(new[] { "k:1:2:3:4" }, result);
         }
 
         [TestMethod]
         public void GetColumns_T5_NullIndices_ThrowsArgumentNullException()
         {
             var protocol = Substitute.For<SLProtocol>();
-            Assert.ThrowsException<ArgumentNullException>(() => protocol.GetColumns<string, int, int, int, int, string>(TableId, null, (a, b, c, d, e) => string.Empty).ToList());
+            Assert.ThrowsException<ArgumentNullException>(() => protocol.GetColumns<string, int, int, int, int, string>(TableId, null, (a, b, c, d, e) => String.Empty).ToList());
         }
 
         [TestMethod]
@@ -256,7 +220,7 @@
         public void GetColumns_T5_WrongColumnCount_ThrowsArgumentOutOfRangeException()
         {
             var protocol = Substitute.For<SLProtocol>();
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => protocol.GetColumns<string, int, int, int, int, string>(TableId, new uint[] { 0, 1, 2, 3 }, (a, b, c, d, e) => string.Empty).ToList());
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => protocol.GetColumns<string, int, int, int, int, string>(TableId, new uint[] { 0, 1, 2, 3 }, (a, b, c, d, e) => String.Empty).ToList());
         }
 
         [TestMethod]
@@ -267,25 +231,14 @@
             // GetColumns calls columnsIdx.ToArray() internally, so the actual NotifyProtocol call
             // receives a new array instance with the same content; match it by value with Arg.Is.
             protocol.NotifyProtocol(321, TableId, Arg.Any<object>())
-                    .Returns(new object[] { new object[] { "a" }, new object[] { "b" } });
+                    .Returns(new object[] { new object[] { "a1", "a2" }, new object[] { "b1", "b2" } });
 
-            protocol.GetColumns(TableId, (IEnumerable<uint>)indices);
+            object[] result = protocol.GetColumns(TableId, (IEnumerable<uint>)indices);
 
             protocol.Received(1).NotifyProtocol(
                 321,
                 TableId,
                 Arg.Is<object>(o => ((uint[])o).SequenceEqual(indices)));
-        }
-
-        [TestMethod]
-        public void GetColumns_IEnumerable_ReturnsOneObjectArrayPerColumn()
-        {
-            var protocol = Substitute.For<SLProtocol>();
-            var indices = new uint[] { 0, 1 };
-            protocol.NotifyProtocol(321, TableId, Arg.Is<object>(o => ((uint[])o).SequenceEqual(indices)))
-                    .Returns(new object[] { new object[] { "a1", "a2" }, new object[] { "b1", "b2" } });
-
-            object[] result = protocol.GetColumns(TableId, (IEnumerable<uint>)indices);
 
             Assert.AreEqual(2, result.Length);
             CollectionAssert.AreEqual(new object[] { "a1", "a2" }, (object[])result[0]);
@@ -322,14 +275,12 @@
         }
 
         [TestMethod]
-        public void GetParameter_T_NullValue_ReturnsDefault()
+        public void GetParameter_T_NullValue_ThrowsInvalidOperationException()
         {
             var protocol = Substitute.For<SLProtocol>();
             protocol.GetParameter(100).Returns((object)null);
 
-            int result = protocol.GetParameter<int>(100);
-
-            Assert.AreEqual(0, result);
+            Assert.ThrowsException<InvalidOperationException>(() => protocol.GetParameter<int>(100));
         }
 
         [TestMethod]
@@ -350,22 +301,12 @@
             var ids = new uint[] { 1, 2 };
             protocol.GetParameters(ids).Returns(new object[] { "10", "hello" });
 
-            protocol.GetParameters<int, string>(ids, out int p1, out string p2);
+            protocol.GetParameters(ids, out int p1, out string p2);
+
+            protocol.Received(1).GetParameters(ids);
 
             Assert.AreEqual(10, p1);
             Assert.AreEqual("hello", p2);
-        }
-
-        [TestMethod]
-        public void GetParameters_T2_DelegatesToSLProtocolGetParameters()
-        {
-            var protocol = Substitute.For<SLProtocol>();
-            var ids = new uint[] { 1, 2 };
-            protocol.GetParameters(ids).Returns(new object[] { "1", "2" });
-
-            protocol.GetParameters<int, int>(ids, out _, out _);
-
-            protocol.Received(1).GetParameters(ids);
         }
 
         [TestMethod]
@@ -389,23 +330,13 @@
             var ids = new uint[] { 1, 2, 3 };
             protocol.GetParameters(ids).Returns(new object[] { "1", "99", "true" });
 
-            protocol.GetParameters<int, double, bool>(ids, out int p1, out double p2, out bool p3);
+            protocol.GetParameters(ids, out int p1, out double p2, out bool p3);
+
+            protocol.Received(1).GetParameters(ids);
 
             Assert.AreEqual(1, p1);
             Assert.AreEqual(99.0, p2);
-            Assert.AreEqual(true, p3);
-        }
-
-        [TestMethod]
-        public void GetParameters_T3_DelegatesToSLProtocolGetParameters()
-        {
-            var protocol = Substitute.For<SLProtocol>();
-            var ids = new uint[] { 1, 2, 3 };
-            protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3" });
-
-            protocol.GetParameters<int, int, int>(ids, out _, out _, out _);
-
-            protocol.Received(1).GetParameters(ids);
+            Assert.IsTrue(p3);
         }
 
         [TestMethod]
@@ -429,24 +360,14 @@
             var ids = new uint[] { 1, 2, 3, 4 };
             protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3", "4" });
 
-            protocol.GetParameters<int, int, int, int>(ids, out int p1, out int p2, out int p3, out int p4);
+            protocol.GetParameters(ids, out int p1, out int p2, out int p3, out int p4);
+
+            protocol.Received(1).GetParameters(ids);
 
             Assert.AreEqual(1, p1);
             Assert.AreEqual(2, p2);
             Assert.AreEqual(3, p3);
             Assert.AreEqual(4, p4);
-        }
-
-        [TestMethod]
-        public void GetParameters_T4_DelegatesToSLProtocolGetParameters()
-        {
-            var protocol = Substitute.For<SLProtocol>();
-            var ids = new uint[] { 1, 2, 3, 4 };
-            protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3", "4" });
-
-            protocol.GetParameters<int, int, int, int>(ids, out _, out _, out _, out _);
-
-            protocol.Received(1).GetParameters(ids);
         }
 
         [TestMethod]
@@ -470,25 +391,15 @@
             var ids = new uint[] { 1, 2, 3, 4, 5 };
             protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3", "4", "5" });
 
-            protocol.GetParameters<int, int, int, int, int>(ids, out int p1, out int p2, out int p3, out int p4, out int p5);
+            protocol.GetParameters(ids, out int p1, out int p2, out int p3, out int p4, out int p5);
+
+            protocol.Received(1).GetParameters(ids);
 
             Assert.AreEqual(1, p1);
             Assert.AreEqual(2, p2);
             Assert.AreEqual(3, p3);
             Assert.AreEqual(4, p4);
             Assert.AreEqual(5, p5);
-        }
-
-        [TestMethod]
-        public void GetParameters_T5_DelegatesToSLProtocolGetParameters()
-        {
-            var protocol = Substitute.For<SLProtocol>();
-            var ids = new uint[] { 1, 2, 3, 4, 5 };
-            protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3", "4", "5" });
-
-            protocol.GetParameters<int, int, int, int, int>(ids, out _, out _, out _, out _, out _);
-
-            protocol.Received(1).GetParameters(ids);
         }
 
         [TestMethod]
@@ -512,7 +423,9 @@
             var ids = new uint[] { 1, 2, 3, 4, 5, 6 };
             protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3", "4", "5", "6" });
 
-            protocol.GetParameters<int, int, int, int, int, int>(ids, out int p1, out int p2, out int p3, out int p4, out int p5, out int p6);
+            protocol.GetParameters(ids, out int p1, out int p2, out int p3, out int p4, out int p5, out int p6);
+
+            protocol.Received(1).GetParameters(ids);
 
             Assert.AreEqual(1, p1);
             Assert.AreEqual(2, p2);
@@ -520,18 +433,6 @@
             Assert.AreEqual(4, p4);
             Assert.AreEqual(5, p5);
             Assert.AreEqual(6, p6);
-        }
-
-        [TestMethod]
-        public void GetParameters_T6_DelegatesToSLProtocolGetParameters()
-        {
-            var protocol = Substitute.For<SLProtocol>();
-            var ids = new uint[] { 1, 2, 3, 4, 5, 6 };
-            protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3", "4", "5", "6" });
-
-            protocol.GetParameters<int, int, int, int, int, int>(ids, out _, out _, out _, out _, out _, out _);
-
-            protocol.Received(1).GetParameters(ids);
         }
 
         [TestMethod]
@@ -555,7 +456,9 @@
             var ids = new uint[] { 1, 2, 3, 4, 5, 6, 7 };
             protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3", "4", "5", "6", "7" });
 
-            protocol.GetParameters<int, int, int, int, int, int, int>(ids, out int p1, out int p2, out int p3, out int p4, out int p5, out int p6, out int p7);
+            protocol.GetParameters(ids, out int p1, out int p2, out int p3, out int p4, out int p5, out int p6, out int p7);
+
+            protocol.Received(1).GetParameters(ids);
 
             Assert.AreEqual(1, p1);
             Assert.AreEqual(2, p2);
@@ -564,18 +467,6 @@
             Assert.AreEqual(5, p5);
             Assert.AreEqual(6, p6);
             Assert.AreEqual(7, p7);
-        }
-
-        [TestMethod]
-        public void GetParameters_T7_DelegatesToSLProtocolGetParameters()
-        {
-            var protocol = Substitute.For<SLProtocol>();
-            var ids = new uint[] { 1, 2, 3, 4, 5, 6, 7 };
-            protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3", "4", "5", "6", "7" });
-
-            protocol.GetParameters<int, int, int, int, int, int, int>(ids, out _, out _, out _, out _, out _, out _, out _);
-
-            protocol.Received(1).GetParameters(ids);
         }
 
         [TestMethod]
@@ -599,7 +490,9 @@
             var ids = new uint[] { 1, 2, 3, 4, 5, 6, 7, 8 };
             protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3", "4", "5", "6", "7", "8" });
 
-            protocol.GetParameters<int, int, int, int, int, int, int, int>(ids, out int p1, out int p2, out int p3, out int p4, out int p5, out int p6, out int p7, out int p8);
+            protocol.GetParameters(ids, out int p1, out int p2, out int p3, out int p4, out int p5, out int p6, out int p7, out int p8);
+
+            protocol.Received(1).GetParameters(ids);
 
             Assert.AreEqual(1, p1);
             Assert.AreEqual(2, p2);
@@ -609,18 +502,6 @@
             Assert.AreEqual(6, p6);
             Assert.AreEqual(7, p7);
             Assert.AreEqual(8, p8);
-        }
-
-        [TestMethod]
-        public void GetParameters_T8_DelegatesToSLProtocolGetParameters()
-        {
-            var protocol = Substitute.For<SLProtocol>();
-            var ids = new uint[] { 1, 2, 3, 4, 5, 6, 7, 8 };
-            protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3", "4", "5", "6", "7", "8" });
-
-            protocol.GetParameters<int, int, int, int, int, int, int, int>(ids, out _, out _, out _, out _, out _, out _, out _, out _);
-
-            protocol.Received(1).GetParameters(ids);
         }
 
         [TestMethod]
@@ -644,7 +525,9 @@
             var ids = new uint[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
             protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3", "4", "5", "6", "7", "8", "9" });
 
-            protocol.GetParameters<int, int, int, int, int, int, int, int, int>(ids, out int p1, out int p2, out int p3, out int p4, out int p5, out int p6, out int p7, out int p8, out int p9);
+            protocol.GetParameters(ids, out int p1, out int p2, out int p3, out int p4, out int p5, out int p6, out int p7, out int p8, out int p9);
+
+            protocol.Received(1).GetParameters(ids);
 
             Assert.AreEqual(1, p1);
             Assert.AreEqual(2, p2);
@@ -655,18 +538,6 @@
             Assert.AreEqual(7, p7);
             Assert.AreEqual(8, p8);
             Assert.AreEqual(9, p9);
-        }
-
-        [TestMethod]
-        public void GetParameters_T9_DelegatesToSLProtocolGetParameters()
-        {
-            var protocol = Substitute.For<SLProtocol>();
-            var ids = new uint[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-            protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3", "4", "5", "6", "7", "8", "9" });
-
-            protocol.GetParameters<int, int, int, int, int, int, int, int, int>(ids, out _, out _, out _, out _, out _, out _, out _, out _, out _);
-
-            protocol.Received(1).GetParameters(ids);
         }
 
         [TestMethod]
@@ -690,7 +561,9 @@
             var ids = new uint[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
             protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3", "4", "5", "6", "7", "8", "9", "10" });
 
-            protocol.GetParameters<int, int, int, int, int, int, int, int, int, int>(ids, out int p1, out int p2, out int p3, out int p4, out int p5, out int p6, out int p7, out int p8, out int p9, out int p10);
+            protocol.GetParameters(ids, out int p1, out int p2, out int p3, out int p4, out int p5, out int p6, out int p7, out int p8, out int p9, out int p10);
+
+            protocol.Received(1).GetParameters(ids);
 
             Assert.AreEqual(1, p1);
             Assert.AreEqual(2, p2);
@@ -702,18 +575,6 @@
             Assert.AreEqual(8, p8);
             Assert.AreEqual(9, p9);
             Assert.AreEqual(10, p10);
-        }
-
-        [TestMethod]
-        public void GetParameters_T10_DelegatesToSLProtocolGetParameters()
-        {
-            var protocol = Substitute.For<SLProtocol>();
-            var ids = new uint[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
-            protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3", "4", "5", "6", "7", "8", "9", "10" });
-
-            protocol.GetParameters<int, int, int, int, int, int, int, int, int, int>(ids, out _, out _, out _, out _, out _, out _, out _, out _, out _, out _);
-
-            protocol.Received(1).GetParameters(ids);
         }
 
         [TestMethod]

--- a/Utils.Protocol.Extension.Tests/ProtocolExtensionTests.cs
+++ b/Utils.Protocol.Extension.Tests/ProtocolExtensionTests.cs
@@ -1,0 +1,733 @@
+﻿namespace Skyline.DataMiner.Utils.Protocol.Extension.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using Skyline.DataMiner.Scripting;
+
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    using NSubstitute;
+
+    [TestClass]
+    public class ProtocolExtensionTests
+    {
+        private const int TableId = 1000;
+
+        [TestMethod]
+        public void GetColumn_T_InvokesNotifyProtocol321WithCorrectTableIdAndColumnIdx()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            uint colIdx = 2;
+            protocol.NotifyProtocol(321, TableId, Arg.Is<object>(o => ((uint[])o).SequenceEqual(new[] { colIdx })))
+                    .Returns(new object[] { new object[] { "1" } });
+
+            protocol.GetColumn<int>(TableId, colIdx).ToList();
+
+            protocol.Received(1).NotifyProtocol(
+                321,
+                TableId,
+                Arg.Is<object>(o => ((uint[])o).SequenceEqual(new[] { colIdx })));
+        }
+
+        [TestMethod]
+        public void GetColumn_T_ReturnsValuesConvertedToRequestedType()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            uint colIdx = 0;
+            protocol.NotifyProtocol(321, TableId, Arg.Is<object>(o => ((uint[])o).SequenceEqual(new[] { colIdx })))
+                    .Returns(new object[] { new object[] { "10", "20", "30" } });
+
+            List<int> result = protocol.GetColumn<int>(TableId, colIdx).ToList();
+
+            CollectionAssert.AreEqual(new[] { 10, 20, 30 }, result);
+        }
+
+        [TestMethod]
+        public void GetColumn_T_EmptyColumn_ReturnsEmptyEnumerable()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            uint colIdx = 0;
+            protocol.NotifyProtocol(321, TableId, Arg.Is<object>(o => ((uint[])o).SequenceEqual(new[] { colIdx })))
+                    .Returns(new object[] { new object[] { } });
+
+            List<int> result = protocol.GetColumn<int>(TableId, colIdx).ToList();
+
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [TestMethod]
+        public void GetColumn_T_NullValues_ReturnDefaults()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            uint colIdx = 0;
+            // DataMiner represents uninitialized cells as null; ChangeType<T> converts null to default(T).
+            protocol.NotifyProtocol(321, TableId, Arg.Is<object>(o => ((uint[])o).SequenceEqual(new[] { colIdx })))
+                    .Returns(new object[] { new object[] { null, null } });
+
+            List<int> result = protocol.GetColumn<int>(TableId, colIdx).ToList();
+
+            CollectionAssert.AreEqual(new[] { 0, 0 }, result);
+        }
+
+        [TestMethod]
+        public void GetColumns_T2_InvokesNotifyProtocol321WithCorrectArguments()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            var indices = new uint[] { 0, 1 };
+            protocol.NotifyProtocol(321, TableId, indices)
+                    .Returns(new object[] { new object[] { "key1" }, new object[] { "10" } });
+
+            protocol.GetColumns<string, int, string>(TableId, indices, (k, v) => $"{k}:{v}").ToList();
+
+            protocol.Received(1).NotifyProtocol(321, TableId, indices);
+        }
+
+        [TestMethod]
+        public void GetColumns_T2_ReturnsSelectorResultForEveryRow()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            var indices = new uint[] { 0, 1 };
+            protocol.NotifyProtocol(321, TableId, indices)
+                    .Returns(new object[] { new object[] { "key1", "key2" }, new object[] { "10", "20" } });
+
+            List<string> result = protocol.GetColumns<string, int, string>(TableId, indices, (k, v) => $"{k}:{v}").ToList();
+
+            CollectionAssert.AreEqual(new[] { "key1:10", "key2:20" }, result);
+        }
+
+        [TestMethod]
+        public void GetColumns_T2_NullIndices_ThrowsArgumentNullException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentNullException>(() => protocol.GetColumns<string, int, string>(TableId, null, (k, v) => string.Empty).ToList());
+        }
+
+        [TestMethod]
+        public void GetColumns_T2_NullSelector_ThrowsArgumentNullException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentNullException>(() => protocol.GetColumns<string, int, string>(TableId, new uint[] { 0, 1 }, (Func<string, int, string>)null).ToList());
+        }
+
+        [TestMethod]
+        public void GetColumns_T2_WrongColumnCount_ThrowsArgumentOutOfRangeException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => protocol.GetColumns<string, int, string>(TableId, new uint[] { 0 }, (k, v) => string.Empty).ToList());
+        }
+
+        [TestMethod]
+        public void GetColumns_T3_InvokesNotifyProtocol321WithCorrectArguments()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            var indices = new uint[] { 0, 1, 2 };
+            protocol.NotifyProtocol(321, TableId, indices)
+                    .Returns(new object[] { new object[] { "key1" }, new object[] { "10" }, new object[] { "true" } });
+
+            protocol.GetColumns<string, int, bool, string>(TableId, indices, (k, v, b) => $"{k}:{v}:{b}").ToList();
+
+            protocol.Received(1).NotifyProtocol(321, TableId, indices);
+        }
+
+        [TestMethod]
+        public void GetColumns_T3_ReturnsSelectorResultForEveryRow()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            var indices = new uint[] { 0, 1, 2 };
+            protocol.NotifyProtocol(321, TableId, Arg.Is<object>(o => ((uint[])o).SequenceEqual(indices)))
+                    .Returns(new object[] { new object[] { "key1", "key2" }, new object[] { "10", "20" }, new object[] { "true", "false" } });
+
+            List<string> result = protocol.GetColumns<string, int, bool, string>(TableId, indices, (k, v, b) => $"{k}:{v}:{b}").ToList();
+
+            CollectionAssert.AreEqual(new[] { "key1:10:True", "key2:20:False" }, result);
+        }
+
+        [TestMethod]
+        public void GetColumns_T3_NullIndices_ThrowsArgumentNullException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentNullException>(() => protocol.GetColumns<string, int, bool, string>(TableId, null, (k, v, b) => string.Empty).ToList());
+        }
+
+        [TestMethod]
+        public void GetColumns_T3_NullSelector_ThrowsArgumentNullException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentNullException>(() => protocol.GetColumns<string, int, bool, string>(TableId, new uint[] { 0, 1, 2 }, (Func<string, int, bool, string>)null).ToList());
+        }
+
+        [TestMethod]
+        public void GetColumns_T3_WrongColumnCount_ThrowsArgumentOutOfRangeException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => protocol.GetColumns<string, int, bool, string>(TableId, new uint[] { 0, 1 }, (k, v, b) => string.Empty).ToList());
+        }
+
+        [TestMethod]
+        public void GetColumns_T4_InvokesNotifyProtocol321WithCorrectArguments()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            var indices = new uint[] { 0, 1, 2, 3 };
+            protocol.NotifyProtocol(321, TableId, indices)
+                    .Returns(new object[] { new object[] { "k" }, new object[] { "1" }, new object[] { "2" }, new object[] { "3" } });
+
+            protocol.GetColumns<string, int, int, int, string>(TableId, indices, (a, b, c, d) => $"{a}:{b}:{c}:{d}").ToList();
+
+            protocol.Received(1).NotifyProtocol(321, TableId, indices);
+        }
+
+        [TestMethod]
+        public void GetColumns_T4_ReturnsSelectorResultForEveryRow()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            var indices = new uint[] { 0, 1, 2, 3 };
+            protocol.NotifyProtocol(321, TableId, indices)
+                    .Returns(new object[] { new object[] { "key1" }, new object[] { "1" }, new object[] { "2" }, new object[] { "3" } });
+
+            List<string> result = protocol.GetColumns<string, int, int, int, string>(TableId, indices, (a, b, c, d) => $"{a}:{b}:{c}:{d}").ToList();
+
+            CollectionAssert.AreEqual(new[] { "key1:1:2:3" }, result);
+        }
+
+        [TestMethod]
+        public void GetColumns_T4_NullIndices_ThrowsArgumentNullException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentNullException>(() => protocol.GetColumns<string, int, int, int, string>(TableId, null, (a, b, c, d) => string.Empty).ToList());
+        }
+
+        [TestMethod]
+        public void GetColumns_T4_NullSelector_ThrowsArgumentNullException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentNullException>(() => protocol.GetColumns<string, int, int, int, string>(TableId, new uint[] { 0, 1, 2, 3 }, (Func<string, int, int, int, string>)null).ToList());
+        }
+
+        [TestMethod]
+        public void GetColumns_T4_WrongColumnCount_ThrowsArgumentOutOfRangeException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => protocol.GetColumns<string, int, int, int, string>(TableId, new uint[] { 0, 1, 2 }, (a, b, c, d) => string.Empty).ToList());
+        }
+
+        [TestMethod]
+        public void GetColumns_T5_InvokesNotifyProtocol321WithCorrectArguments()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            var indices = new uint[] { 0, 1, 2, 3, 4 };
+            protocol.NotifyProtocol(321, TableId, indices)
+                    .Returns(new object[] { new object[] { "k" }, new object[] { "1" }, new object[] { "2" }, new object[] { "3" }, new object[] { "4" } });
+
+            protocol.GetColumns<string, int, int, int, int, string>(TableId, indices, (a, b, c, d, e) => $"{a}:{b}:{c}:{d}:{e}").ToList();
+
+            protocol.Received(1).NotifyProtocol(321, TableId, indices);
+        }
+
+        [TestMethod]
+        public void GetColumns_T5_ReturnsSelectorResultForEveryRow()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            var indices = new uint[] { 0, 1, 2, 3, 4 };
+            protocol.NotifyProtocol(321, TableId, indices)
+                    .Returns(new object[] { new object[] { "key1" }, new object[] { "1" }, new object[] { "2" }, new object[] { "3" }, new object[] { "4" } });
+
+            List<string> result = protocol.GetColumns<string, int, int, int, int, string>(TableId, indices, (a, b, c, d, e) => $"{a}:{b}:{c}:{d}:{e}").ToList();
+
+            CollectionAssert.AreEqual(new[] { "key1:1:2:3:4" }, result);
+        }
+
+        [TestMethod]
+        public void GetColumns_T5_NullIndices_ThrowsArgumentNullException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentNullException>(() => protocol.GetColumns<string, int, int, int, int, string>(TableId, null, (a, b, c, d, e) => string.Empty).ToList());
+        }
+
+        [TestMethod]
+        public void GetColumns_T5_NullSelector_ThrowsArgumentNullException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentNullException>(() => protocol.GetColumns<string, int, int, int, int, string>(TableId, new uint[] { 0, 1, 2, 3, 4 }, (Func<string, int, int, int, int, string>)null).ToList());
+        }
+
+        [TestMethod]
+        public void GetColumns_T5_WrongColumnCount_ThrowsArgumentOutOfRangeException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => protocol.GetColumns<string, int, int, int, int, string>(TableId, new uint[] { 0, 1, 2, 3 }, (a, b, c, d, e) => string.Empty).ToList());
+        }
+
+        [TestMethod]
+        public void GetColumns_IEnumerable_InvokesNotifyProtocol321WithCorrectArguments()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            var indices = new uint[] { 0, 1 };
+            // GetColumns calls columnsIdx.ToArray() internally, so the actual NotifyProtocol call
+            // receives a new array instance with the same content; match it by value with Arg.Is.
+            protocol.NotifyProtocol(321, TableId, Arg.Any<object>())
+                    .Returns(new object[] { new object[] { "a" }, new object[] { "b" } });
+
+            protocol.GetColumns(TableId, (IEnumerable<uint>)indices);
+
+            protocol.Received(1).NotifyProtocol(
+                321,
+                TableId,
+                Arg.Is<object>(o => ((uint[])o).SequenceEqual(indices)));
+        }
+
+        [TestMethod]
+        public void GetColumns_IEnumerable_ReturnsOneObjectArrayPerColumn()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            var indices = new uint[] { 0, 1 };
+            protocol.NotifyProtocol(321, TableId, Arg.Is<object>(o => ((uint[])o).SequenceEqual(indices)))
+                    .Returns(new object[] { new object[] { "a1", "a2" }, new object[] { "b1", "b2" } });
+
+            object[] result = protocol.GetColumns(TableId, (IEnumerable<uint>)indices);
+
+            Assert.AreEqual(2, result.Length);
+            CollectionAssert.AreEqual(new object[] { "a1", "a2" }, (object[])result[0]);
+            CollectionAssert.AreEqual(new object[] { "b1", "b2" }, (object[])result[1]);
+        }
+
+        [TestMethod]
+        public void GetColumns_IEnumerable_EmptyIndices_ReturnsEmptyArray()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+
+            object[] result = protocol.GetColumns(TableId, Enumerable.Empty<uint>());
+
+            Assert.AreEqual(0, result.Length);
+            protocol.DidNotReceive().NotifyProtocol(Arg.Any<int>(), Arg.Any<object>(), Arg.Any<object>());
+        }
+
+        [TestMethod]
+        public void GetColumns_IEnumerable_NullIndices_ThrowsArgumentNullException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentNullException>(() => protocol.GetColumns(TableId, (IEnumerable<uint>)null));
+        }
+
+        [TestMethod]
+        public void GetParameter_T_ReturnsValueConvertedToRequestedType()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            protocol.GetParameter(100).Returns("42");
+
+            int result = protocol.GetParameter<int>(100);
+
+            Assert.AreEqual(42, result);
+        }
+
+        [TestMethod]
+        public void GetParameter_T_NullValue_ReturnsDefault()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            protocol.GetParameter(100).Returns((object)null);
+
+            int result = protocol.GetParameter<int>(100);
+
+            Assert.AreEqual(0, result);
+        }
+
+        [TestMethod]
+        public void GetParameter_T_DelegatesToSLProtocolGetParameter()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            protocol.GetParameter(200).Returns("7");
+
+            protocol.GetParameter<int>(200);
+
+            protocol.Received(1).GetParameter(200);
+        }
+
+        [TestMethod]
+        public void GetParameters_T2_ValuesAreConvertedToRequestedTypes()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            var ids = new uint[] { 1, 2 };
+            protocol.GetParameters(ids).Returns(new object[] { "10", "hello" });
+
+            protocol.GetParameters<int, string>(ids, out int p1, out string p2);
+
+            Assert.AreEqual(10, p1);
+            Assert.AreEqual("hello", p2);
+        }
+
+        [TestMethod]
+        public void GetParameters_T2_DelegatesToSLProtocolGetParameters()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            var ids = new uint[] { 1, 2 };
+            protocol.GetParameters(ids).Returns(new object[] { "1", "2" });
+
+            protocol.GetParameters<int, int>(ids, out _, out _);
+
+            protocol.Received(1).GetParameters(ids);
+        }
+
+        [TestMethod]
+        public void GetParameters_T2_NullIds_ThrowsArgumentNullException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentNullException>(() => protocol.GetParameters<int, string>(null, out _, out _));
+        }
+
+        [TestMethod]
+        public void GetParameters_T2_WrongIdCount_ThrowsArgumentOutOfRangeException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => protocol.GetParameters<int, string>(new uint[] { 1 }, out _, out _));
+        }
+
+        [TestMethod]
+        public void GetParameters_T3_ValuesAreConvertedToRequestedTypes()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            var ids = new uint[] { 1, 2, 3 };
+            protocol.GetParameters(ids).Returns(new object[] { "1", "99", "true" });
+
+            protocol.GetParameters<int, double, bool>(ids, out int p1, out double p2, out bool p3);
+
+            Assert.AreEqual(1, p1);
+            Assert.AreEqual(99.0, p2);
+            Assert.AreEqual(true, p3);
+        }
+
+        [TestMethod]
+        public void GetParameters_T3_DelegatesToSLProtocolGetParameters()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            var ids = new uint[] { 1, 2, 3 };
+            protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3" });
+
+            protocol.GetParameters<int, int, int>(ids, out _, out _, out _);
+
+            protocol.Received(1).GetParameters(ids);
+        }
+
+        [TestMethod]
+        public void GetParameters_T3_NullIds_ThrowsArgumentNullException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentNullException>(() => protocol.GetParameters<int, int, int>(null, out _, out _, out _));
+        }
+
+        [TestMethod]
+        public void GetParameters_T3_WrongIdCount_ThrowsArgumentOutOfRangeException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => protocol.GetParameters<int, int, int>(new uint[] { 1, 2 }, out _, out _, out _));
+        }
+
+        [TestMethod]
+        public void GetParameters_T4_ValuesAreConvertedToRequestedTypes()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            var ids = new uint[] { 1, 2, 3, 4 };
+            protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3", "4" });
+
+            protocol.GetParameters<int, int, int, int>(ids, out int p1, out int p2, out int p3, out int p4);
+
+            Assert.AreEqual(1, p1);
+            Assert.AreEqual(2, p2);
+            Assert.AreEqual(3, p3);
+            Assert.AreEqual(4, p4);
+        }
+
+        [TestMethod]
+        public void GetParameters_T4_DelegatesToSLProtocolGetParameters()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            var ids = new uint[] { 1, 2, 3, 4 };
+            protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3", "4" });
+
+            protocol.GetParameters<int, int, int, int>(ids, out _, out _, out _, out _);
+
+            protocol.Received(1).GetParameters(ids);
+        }
+
+        [TestMethod]
+        public void GetParameters_T4_NullIds_ThrowsArgumentNullException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentNullException>(() => protocol.GetParameters<int, int, int, int>(null, out _, out _, out _, out _));
+        }
+
+        [TestMethod]
+        public void GetParameters_T4_WrongIdCount_ThrowsArgumentOutOfRangeException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => protocol.GetParameters<int, int, int, int>(new uint[] { 1, 2, 3 }, out _, out _, out _, out _));
+        }
+
+        [TestMethod]
+        public void GetParameters_T5_ValuesAreConvertedToRequestedTypes()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            var ids = new uint[] { 1, 2, 3, 4, 5 };
+            protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3", "4", "5" });
+
+            protocol.GetParameters<int, int, int, int, int>(ids, out int p1, out int p2, out int p3, out int p4, out int p5);
+
+            Assert.AreEqual(1, p1);
+            Assert.AreEqual(2, p2);
+            Assert.AreEqual(3, p3);
+            Assert.AreEqual(4, p4);
+            Assert.AreEqual(5, p5);
+        }
+
+        [TestMethod]
+        public void GetParameters_T5_DelegatesToSLProtocolGetParameters()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            var ids = new uint[] { 1, 2, 3, 4, 5 };
+            protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3", "4", "5" });
+
+            protocol.GetParameters<int, int, int, int, int>(ids, out _, out _, out _, out _, out _);
+
+            protocol.Received(1).GetParameters(ids);
+        }
+
+        [TestMethod]
+        public void GetParameters_T5_NullIds_ThrowsArgumentNullException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentNullException>(() => protocol.GetParameters<int, int, int, int, int>(null, out _, out _, out _, out _, out _));
+        }
+
+        [TestMethod]
+        public void GetParameters_T5_WrongIdCount_ThrowsArgumentOutOfRangeException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => protocol.GetParameters<int, int, int, int, int>(new uint[] { 1, 2, 3, 4 }, out _, out _, out _, out _, out _));
+        }
+
+        [TestMethod]
+        public void GetParameters_T6_ValuesAreConvertedToRequestedTypes()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            var ids = new uint[] { 1, 2, 3, 4, 5, 6 };
+            protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3", "4", "5", "6" });
+
+            protocol.GetParameters<int, int, int, int, int, int>(ids, out int p1, out int p2, out int p3, out int p4, out int p5, out int p6);
+
+            Assert.AreEqual(1, p1);
+            Assert.AreEqual(2, p2);
+            Assert.AreEqual(3, p3);
+            Assert.AreEqual(4, p4);
+            Assert.AreEqual(5, p5);
+            Assert.AreEqual(6, p6);
+        }
+
+        [TestMethod]
+        public void GetParameters_T6_DelegatesToSLProtocolGetParameters()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            var ids = new uint[] { 1, 2, 3, 4, 5, 6 };
+            protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3", "4", "5", "6" });
+
+            protocol.GetParameters<int, int, int, int, int, int>(ids, out _, out _, out _, out _, out _, out _);
+
+            protocol.Received(1).GetParameters(ids);
+        }
+
+        [TestMethod]
+        public void GetParameters_T6_NullIds_ThrowsArgumentNullException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentNullException>(() => protocol.GetParameters<int, int, int, int, int, int>(null, out _, out _, out _, out _, out _, out _));
+        }
+
+        [TestMethod]
+        public void GetParameters_T6_WrongIdCount_ThrowsArgumentOutOfRangeException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => protocol.GetParameters<int, int, int, int, int, int>(new uint[] { 1, 2, 3, 4, 5 }, out _, out _, out _, out _, out _, out _));
+        }
+
+        [TestMethod]
+        public void GetParameters_T7_ValuesAreConvertedToRequestedTypes()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            var ids = new uint[] { 1, 2, 3, 4, 5, 6, 7 };
+            protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3", "4", "5", "6", "7" });
+
+            protocol.GetParameters<int, int, int, int, int, int, int>(ids, out int p1, out int p2, out int p3, out int p4, out int p5, out int p6, out int p7);
+
+            Assert.AreEqual(1, p1);
+            Assert.AreEqual(2, p2);
+            Assert.AreEqual(3, p3);
+            Assert.AreEqual(4, p4);
+            Assert.AreEqual(5, p5);
+            Assert.AreEqual(6, p6);
+            Assert.AreEqual(7, p7);
+        }
+
+        [TestMethod]
+        public void GetParameters_T7_DelegatesToSLProtocolGetParameters()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            var ids = new uint[] { 1, 2, 3, 4, 5, 6, 7 };
+            protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3", "4", "5", "6", "7" });
+
+            protocol.GetParameters<int, int, int, int, int, int, int>(ids, out _, out _, out _, out _, out _, out _, out _);
+
+            protocol.Received(1).GetParameters(ids);
+        }
+
+        [TestMethod]
+        public void GetParameters_T7_NullIds_ThrowsArgumentNullException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentNullException>(() => protocol.GetParameters<int, int, int, int, int, int, int>(null, out _, out _, out _, out _, out _, out _, out _));
+        }
+
+        [TestMethod]
+        public void GetParameters_T7_WrongIdCount_ThrowsArgumentOutOfRangeException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => protocol.GetParameters<int, int, int, int, int, int, int>(new uint[] { 1, 2, 3, 4, 5, 6 }, out _, out _, out _, out _, out _, out _, out _));
+        }
+
+        [TestMethod]
+        public void GetParameters_T8_ValuesAreConvertedToRequestedTypes()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            var ids = new uint[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+            protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3", "4", "5", "6", "7", "8" });
+
+            protocol.GetParameters<int, int, int, int, int, int, int, int>(ids, out int p1, out int p2, out int p3, out int p4, out int p5, out int p6, out int p7, out int p8);
+
+            Assert.AreEqual(1, p1);
+            Assert.AreEqual(2, p2);
+            Assert.AreEqual(3, p3);
+            Assert.AreEqual(4, p4);
+            Assert.AreEqual(5, p5);
+            Assert.AreEqual(6, p6);
+            Assert.AreEqual(7, p7);
+            Assert.AreEqual(8, p8);
+        }
+
+        [TestMethod]
+        public void GetParameters_T8_DelegatesToSLProtocolGetParameters()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            var ids = new uint[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+            protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3", "4", "5", "6", "7", "8" });
+
+            protocol.GetParameters<int, int, int, int, int, int, int, int>(ids, out _, out _, out _, out _, out _, out _, out _, out _);
+
+            protocol.Received(1).GetParameters(ids);
+        }
+
+        [TestMethod]
+        public void GetParameters_T8_NullIds_ThrowsArgumentNullException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentNullException>(() => protocol.GetParameters<int, int, int, int, int, int, int, int>(null, out _, out _, out _, out _, out _, out _, out _, out _));
+        }
+
+        [TestMethod]
+        public void GetParameters_T8_WrongIdCount_ThrowsArgumentOutOfRangeException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => protocol.GetParameters<int, int, int, int, int, int, int, int>(new uint[] { 1, 2, 3, 4, 5, 6, 7 }, out _, out _, out _, out _, out _, out _, out _, out _));
+        }
+
+        [TestMethod]
+        public void GetParameters_T9_ValuesAreConvertedToRequestedTypes()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            var ids = new uint[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+            protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3", "4", "5", "6", "7", "8", "9" });
+
+            protocol.GetParameters<int, int, int, int, int, int, int, int, int>(ids, out int p1, out int p2, out int p3, out int p4, out int p5, out int p6, out int p7, out int p8, out int p9);
+
+            Assert.AreEqual(1, p1);
+            Assert.AreEqual(2, p2);
+            Assert.AreEqual(3, p3);
+            Assert.AreEqual(4, p4);
+            Assert.AreEqual(5, p5);
+            Assert.AreEqual(6, p6);
+            Assert.AreEqual(7, p7);
+            Assert.AreEqual(8, p8);
+            Assert.AreEqual(9, p9);
+        }
+
+        [TestMethod]
+        public void GetParameters_T9_DelegatesToSLProtocolGetParameters()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            var ids = new uint[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+            protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3", "4", "5", "6", "7", "8", "9" });
+
+            protocol.GetParameters<int, int, int, int, int, int, int, int, int>(ids, out _, out _, out _, out _, out _, out _, out _, out _, out _);
+
+            protocol.Received(1).GetParameters(ids);
+        }
+
+        [TestMethod]
+        public void GetParameters_T9_NullIds_ThrowsArgumentNullException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentNullException>(() => protocol.GetParameters<int, int, int, int, int, int, int, int, int>(null, out _, out _, out _, out _, out _, out _, out _, out _, out _));
+        }
+
+        [TestMethod]
+        public void GetParameters_T9_WrongIdCount_ThrowsArgumentOutOfRangeException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => protocol.GetParameters<int, int, int, int, int, int, int, int, int>(new uint[] { 1, 2, 3, 4, 5, 6, 7, 8 }, out _, out _, out _, out _, out _, out _, out _, out _, out _));
+        }
+
+        [TestMethod]
+        public void GetParameters_T10_ValuesAreConvertedToRequestedTypes()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            var ids = new uint[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+            protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3", "4", "5", "6", "7", "8", "9", "10" });
+
+            protocol.GetParameters<int, int, int, int, int, int, int, int, int, int>(ids, out int p1, out int p2, out int p3, out int p4, out int p5, out int p6, out int p7, out int p8, out int p9, out int p10);
+
+            Assert.AreEqual(1, p1);
+            Assert.AreEqual(2, p2);
+            Assert.AreEqual(3, p3);
+            Assert.AreEqual(4, p4);
+            Assert.AreEqual(5, p5);
+            Assert.AreEqual(6, p6);
+            Assert.AreEqual(7, p7);
+            Assert.AreEqual(8, p8);
+            Assert.AreEqual(9, p9);
+            Assert.AreEqual(10, p10);
+        }
+
+        [TestMethod]
+        public void GetParameters_T10_DelegatesToSLProtocolGetParameters()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            var ids = new uint[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+            protocol.GetParameters(ids).Returns(new object[] { "1", "2", "3", "4", "5", "6", "7", "8", "9", "10" });
+
+            protocol.GetParameters<int, int, int, int, int, int, int, int, int, int>(ids, out _, out _, out _, out _, out _, out _, out _, out _, out _, out _);
+
+            protocol.Received(1).GetParameters(ids);
+        }
+
+        [TestMethod]
+        public void GetParameters_T10_NullIds_ThrowsArgumentNullException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentNullException>(() => protocol.GetParameters<int, int, int, int, int, int, int, int, int, int>(null, out _, out _, out _, out _, out _, out _, out _, out _, out _, out _));
+        }
+
+        [TestMethod]
+        public void GetParameters_T10_WrongIdCount_ThrowsArgumentOutOfRangeException()
+        {
+            var protocol = Substitute.For<SLProtocol>();
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => protocol.GetParameters<int, int, int, int, int, int, int, int, int, int>(new uint[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 }, out _, out _, out _, out _, out _, out _, out _, out _, out _, out _));
+        }
+    }
+}

--- a/Utils.Protocol.Extension.Tests/Utils.Protocol.Extension.Tests.csproj
+++ b/Utils.Protocol.Extension.Tests/Utils.Protocol.Extension.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net462</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
+    <PackageReference Include="NSubstitute" Version="4.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Utils.Protocol.Extension\Utils.Protocol.Extension.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Utils.Protocol.Extension/ProtocolExtension.cs
+++ b/Utils.Protocol.Extension/ProtocolExtension.cs
@@ -272,22 +272,22 @@
         }
 
         /// <summary>
-		/// Gets four columns from a table and returns an array with the given selector.
-		/// </summary>
-		/// <typeparam name="T1">Type of the first Column.</typeparam>
-		/// <typeparam name="T2">Type of the second Column.</typeparam>
-		/// <typeparam name="T3">Type of the third Column.</typeparam>
-		/// <typeparam name="T4">Type of the fourth Column.</typeparam>
-		/// <typeparam name="TReturn">Type of the return value.</typeparam>
+        /// Gets four columns from a table and returns an array with the given selector.
+        /// </summary>
+        /// <typeparam name="T1">Type of the first Column.</typeparam>
+        /// <typeparam name="T2">Type of the second Column.</typeparam>
+        /// <typeparam name="T3">Type of the third Column.</typeparam>
+        /// <typeparam name="T4">Type of the fourth Column.</typeparam>
+        /// <typeparam name="TReturn">Type of the return value.</typeparam>
         /// <param name="protocol">Link with SLProtocol process.</param>
         /// <param name="tableId">Id of the table to fetch the columns from.</param>
-		/// <param name="columnIndices">Array with the Columns Indexes.</param>
-		/// <param name="returnSelector">A function to map each column element to a return element.</param>
-		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+        /// <param name="columnIndices">Array with the Columns Indexes.</param>
+        /// <param name="returnSelector">A function to map each column element to a return element.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="columnIndices"/> or <paramref name="returnSelector"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">
-		/// Number of columns doesn't match the number of returned members.
-		/// </exception>
+        /// Number of columns doesn't match the number of returned members.
+        /// </exception>
         /// <exception cref="InvalidOperationException">Thrown if the returned data is null, not in the expected format, or contains inconsistent row counts across columns.</exception>
         public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices, Func<T1, T2, T3, T4, TReturn> returnSelector)
             where T1 : IConvertible
@@ -307,23 +307,23 @@
         }
 
         /// <summary>
-		/// Gets five columns from a table and returns an array with the given selector.
-		/// </summary>
-		/// <typeparam name="T1">Type of the first Column.</typeparam>
-		/// <typeparam name="T2">Type of the second Column.</typeparam>
-		/// <typeparam name="T3">Type of the third Column.</typeparam>
-		/// <typeparam name="T4">Type of the fourth Column.</typeparam>
-		/// <typeparam name="T5">Type of the fifth Column.</typeparam>
-		/// <typeparam name="TReturn">Type of the return value.</typeparam>
+        /// Gets five columns from a table and returns an array with the given selector.
+        /// </summary>
+        /// <typeparam name="T1">Type of the first Column.</typeparam>
+        /// <typeparam name="T2">Type of the second Column.</typeparam>
+        /// <typeparam name="T3">Type of the third Column.</typeparam>
+        /// <typeparam name="T4">Type of the fourth Column.</typeparam>
+        /// <typeparam name="T5">Type of the fifth Column.</typeparam>
+        /// <typeparam name="TReturn">Type of the return value.</typeparam>
         /// <param name="protocol">Link with SLProtocol process.</param>
         /// <param name="tableId">Id of the table to fetch the columns from.</param>
-		/// <param name="columnIndices">Array with the Columns Indexes.</param>
-		/// <param name="returnSelector">A function to map each column element to a return element.</param>
-		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+        /// <param name="columnIndices">Array with the Columns Indexes.</param>
+        /// <param name="returnSelector">A function to map each column element to a return element.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="columnIndices"/> or <paramref name="returnSelector"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">
-		/// Number of columns doesn't match the number of returned members.
-		/// </exception>
+        /// Number of columns doesn't match the number of returned members.
+        /// </exception>
         /// <exception cref="InvalidOperationException">Thrown if the returned data is null, not in the expected format, or contains inconsistent row counts across columns.</exception>
         public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices, Func<T1, T2, T3, T4, T5, TReturn> returnSelector)
             where T1 : IConvertible
@@ -344,24 +344,24 @@
         }
 
         /// <summary>
-		/// Gets six columns from a table and returns an array with the given selector.
-		/// </summary>
-		/// <typeparam name="T1">Type of the first Column.</typeparam>
-		/// <typeparam name="T2">Type of the second Column.</typeparam>
-		/// <typeparam name="T3">Type of the third Column.</typeparam>
-		/// <typeparam name="T4">Type of the fourth Column.</typeparam>
-		/// <typeparam name="T5">Type of the fifth Column.</typeparam>
-		/// <typeparam name="T6">Type of the sixth Column.</typeparam>
-		/// <typeparam name="TReturn">Type of the return value.</typeparam>
+        /// Gets six columns from a table and returns an array with the given selector.
+        /// </summary>
+        /// <typeparam name="T1">Type of the first Column.</typeparam>
+        /// <typeparam name="T2">Type of the second Column.</typeparam>
+        /// <typeparam name="T3">Type of the third Column.</typeparam>
+        /// <typeparam name="T4">Type of the fourth Column.</typeparam>
+        /// <typeparam name="T5">Type of the fifth Column.</typeparam>
+        /// <typeparam name="T6">Type of the sixth Column.</typeparam>
+        /// <typeparam name="TReturn">Type of the return value.</typeparam>
         /// <param name="protocol">Link with SLProtocol process.</param>
         /// <param name="tableId">Id of the table to fetch the columns from.</param>
-		/// <param name="columnIndices">Array with the Columns Indexes.</param>
-		/// <param name="returnSelector">A function to map each column element to a return element.</param>
-		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+        /// <param name="columnIndices">Array with the Columns Indexes.</param>
+        /// <param name="returnSelector">A function to map each column element to a return element.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="columnIndices"/> or <paramref name="returnSelector"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">
-		/// Number of columns doesn't match the number of returned members.
-		/// </exception>
+        /// Number of columns doesn't match the number of returned members.
+        /// </exception>
         /// <exception cref="InvalidOperationException">Thrown if the returned data is null, not in the expected format, or contains inconsistent row counts across columns.</exception>
         public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
             Func<T1, T2, T3, T4, T5, T6, TReturn> returnSelector)
@@ -384,25 +384,25 @@
         }
 
         /// <summary>
-		/// Gets seven columns from a table and returns an array with the given selector.
-		/// </summary>
-		/// <typeparam name="T1">Type of the first Column.</typeparam>
-		/// <typeparam name="T2">Type of the second Column.</typeparam>
-		/// <typeparam name="T3">Type of the third Column.</typeparam>
-		/// <typeparam name="T4">Type of the fourth Column.</typeparam>
-		/// <typeparam name="T5">Type of the fifth Column.</typeparam>
-		/// <typeparam name="T6">Type of the sixth Column.</typeparam>
-		/// <typeparam name="T7">Type of the seventh Column.</typeparam>
-		/// <typeparam name="TReturn">Type of the return value.</typeparam>
+        /// Gets seven columns from a table and returns an array with the given selector.
+        /// </summary>
+        /// <typeparam name="T1">Type of the first Column.</typeparam>
+        /// <typeparam name="T2">Type of the second Column.</typeparam>
+        /// <typeparam name="T3">Type of the third Column.</typeparam>
+        /// <typeparam name="T4">Type of the fourth Column.</typeparam>
+        /// <typeparam name="T5">Type of the fifth Column.</typeparam>
+        /// <typeparam name="T6">Type of the sixth Column.</typeparam>
+        /// <typeparam name="T7">Type of the seventh Column.</typeparam>
+        /// <typeparam name="TReturn">Type of the return value.</typeparam>
         /// <param name="protocol">Link with SLProtocol process.</param>
         /// <param name="tableId">Id of the table to fetch the columns from.</param>
-		/// <param name="columnIndices">Array with the Columns Indexes.</param>
-		/// <param name="returnSelector">A function to map each column element to a return element.</param>
-		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+        /// <param name="columnIndices">Array with the Columns Indexes.</param>
+        /// <param name="returnSelector">A function to map each column element to a return element.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="columnIndices"/> or <paramref name="returnSelector"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">
-		/// Number of columns doesn't match the number of returned members.
-		/// </exception>
+        /// Number of columns doesn't match the number of returned members.
+        /// </exception>
         /// <exception cref="InvalidOperationException">Thrown if the returned data is null, not in the expected format, or contains inconsistent row counts across columns.</exception>
         public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, T7, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
             Func<T1, T2, T3, T4, T5, T6, T7, TReturn> returnSelector)
@@ -426,26 +426,26 @@
         }
 
         /// <summary>
-		/// Gets eight columns from a table and returns an array with the given selector.
-		/// </summary>
-		/// <typeparam name="T1">Type of the first Column.</typeparam>
-		/// <typeparam name="T2">Type of the second Column.</typeparam>
-		/// <typeparam name="T3">Type of the third Column.</typeparam>
-		/// <typeparam name="T4">Type of the fourth Column.</typeparam>
-		/// <typeparam name="T5">Type of the fifth Column.</typeparam>
-		/// <typeparam name="T6">Type of the sixth Column.</typeparam>
-		/// <typeparam name="T7">Type of the seventh Column.</typeparam>
-		/// <typeparam name="T8">Type of the eighth Column.</typeparam>
-		/// <typeparam name="TReturn">Type of the return value.</typeparam>
+        /// Gets eight columns from a table and returns an array with the given selector.
+        /// </summary>
+        /// <typeparam name="T1">Type of the first Column.</typeparam>
+        /// <typeparam name="T2">Type of the second Column.</typeparam>
+        /// <typeparam name="T3">Type of the third Column.</typeparam>
+        /// <typeparam name="T4">Type of the fourth Column.</typeparam>
+        /// <typeparam name="T5">Type of the fifth Column.</typeparam>
+        /// <typeparam name="T6">Type of the sixth Column.</typeparam>
+        /// <typeparam name="T7">Type of the seventh Column.</typeparam>
+        /// <typeparam name="T8">Type of the eighth Column.</typeparam>
+        /// <typeparam name="TReturn">Type of the return value.</typeparam>
         /// <param name="protocol">Link with SLProtocol process.</param>
         /// <param name="tableId">Id of the table to fetch the columns from.</param>
-		/// <param name="columnIndices">Array with the Columns Indexes.</param>
-		/// <param name="returnSelector">A function to map each column element to a return element.</param>
-		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+        /// <param name="columnIndices">Array with the Columns Indexes.</param>
+        /// <param name="returnSelector">A function to map each column element to a return element.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="columnIndices"/> or <paramref name="returnSelector"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">
-		/// Number of columns doesn't match the number of returned members.
-		/// </exception>
+        /// Number of columns doesn't match the number of returned members.
+        /// </exception>
         /// <exception cref="InvalidOperationException">Thrown if the returned data is null, not in the expected format, or contains inconsistent row counts across columns.</exception>
         public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, T7, T8, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
             Func<T1, T2, T3, T4, T5, T6, T7, T8, TReturn> returnSelector)
@@ -470,27 +470,27 @@
         }
 
         /// <summary>
-		/// Gets nine columns from a table and returns an array with the given selector.
-		/// </summary>
-		/// <typeparam name="T1">Type of the first Column.</typeparam>
-		/// <typeparam name="T2">Type of the second Column.</typeparam>
-		/// <typeparam name="T3">Type of the third Column.</typeparam>
-		/// <typeparam name="T4">Type of the fourth Column.</typeparam>
-		/// <typeparam name="T5">Type of the fifth Column.</typeparam>
-		/// <typeparam name="T6">Type of the sixth Column.</typeparam>
-		/// <typeparam name="T7">Type of the seventh Column.</typeparam>
-		/// <typeparam name="T8">Type of the eighth Column.</typeparam>
-		/// <typeparam name="T9">Type of the ninth Column.</typeparam>
-		/// <typeparam name="TReturn">Type of the return value.</typeparam>
+        /// Gets nine columns from a table and returns an array with the given selector.
+        /// </summary>
+        /// <typeparam name="T1">Type of the first Column.</typeparam>
+        /// <typeparam name="T2">Type of the second Column.</typeparam>
+        /// <typeparam name="T3">Type of the third Column.</typeparam>
+        /// <typeparam name="T4">Type of the fourth Column.</typeparam>
+        /// <typeparam name="T5">Type of the fifth Column.</typeparam>
+        /// <typeparam name="T6">Type of the sixth Column.</typeparam>
+        /// <typeparam name="T7">Type of the seventh Column.</typeparam>
+        /// <typeparam name="T8">Type of the eighth Column.</typeparam>
+        /// <typeparam name="T9">Type of the ninth Column.</typeparam>
+        /// <typeparam name="TReturn">Type of the return value.</typeparam>
         /// <param name="protocol">Link with SLProtocol process.</param>
-		/// <param name="tableId">Id of the table to fetch the columns from.</param>
-		/// <param name="columnIndices">Array with the Columns Indexes.</param>
-		/// <param name="returnSelector">A function to map each column element to a return element.</param>
-		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+        /// <param name="tableId">Id of the table to fetch the columns from.</param>
+        /// <param name="columnIndices">Array with the Columns Indexes.</param>
+        /// <param name="returnSelector">A function to map each column element to a return element.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="columnIndices"/> or <paramref name="returnSelector"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">
-		/// Number of columns doesn't match the number of returned members.
-		/// </exception>
+        /// Number of columns doesn't match the number of returned members.
+        /// </exception>
         /// <exception cref="InvalidOperationException">Thrown if the returned data is null, not in the expected format, or contains inconsistent row counts across columns.</exception>
         public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, T7, T8, T9, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TReturn> returnSelector)
@@ -565,29 +565,29 @@
         }
 
         /// <summary>
-		/// Gets eleven columns from a table and returns an array with the given selector.
-		/// </summary>
-		/// <typeparam name="T1">Type of the first Column.</typeparam>
-		/// <typeparam name="T2">Type of the second Column.</typeparam>
-		/// <typeparam name="T3">Type of the third Column.</typeparam>
-		/// <typeparam name="T4">Type of the fourth Column.</typeparam>
-		/// <typeparam name="T5">Type of the fifth Column.</typeparam>
-		/// <typeparam name="T6">Type of the sixth Column.</typeparam>
-		/// <typeparam name="T7">Type of the seventh Column.</typeparam>
-		/// <typeparam name="T8">Type of the eighth Column.</typeparam>
-		/// <typeparam name="T9">Type of the ninth Column.</typeparam>
-		/// <typeparam name="T10">Type of the tenth Column.</typeparam>
-		/// <typeparam name="T11">Type of the eleventh Column.</typeparam>
-		/// <typeparam name="TReturn">Type of the return value.</typeparam>
+        /// Gets eleven columns from a table and returns an array with the given selector.
+        /// </summary>
+        /// <typeparam name="T1">Type of the first Column.</typeparam>
+        /// <typeparam name="T2">Type of the second Column.</typeparam>
+        /// <typeparam name="T3">Type of the third Column.</typeparam>
+        /// <typeparam name="T4">Type of the fourth Column.</typeparam>
+        /// <typeparam name="T5">Type of the fifth Column.</typeparam>
+        /// <typeparam name="T6">Type of the sixth Column.</typeparam>
+        /// <typeparam name="T7">Type of the seventh Column.</typeparam>
+        /// <typeparam name="T8">Type of the eighth Column.</typeparam>
+        /// <typeparam name="T9">Type of the ninth Column.</typeparam>
+        /// <typeparam name="T10">Type of the tenth Column.</typeparam>
+        /// <typeparam name="T11">Type of the eleventh Column.</typeparam>
+        /// <typeparam name="TReturn">Type of the return value.</typeparam>
         /// <param name="protocol">Link with SLProtocol process.</param>
-		/// <param name="tableId">Id of the table to fetch the columns from.</param>
-		/// <param name="columnIndices">Array with the Columns Indexes.</param>
-		/// <param name="returnSelector">A function to map each column element to a return element.</param>
-		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+        /// <param name="tableId">Id of the table to fetch the columns from.</param>
+        /// <param name="columnIndices">Array with the Columns Indexes.</param>
+        /// <param name="returnSelector">A function to map each column element to a return element.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="columnIndices"/> or <paramref name="returnSelector"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">
-		/// Number of columns doesn't match the number of returned members.
-		/// </exception>
+        /// Number of columns doesn't match the number of returned members.
+        /// </exception>
         /// <exception cref="InvalidOperationException">Thrown if the returned data is null, not in the expected format, or contains inconsistent row counts across columns.</exception>
         public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TReturn> returnSelector)
@@ -615,30 +615,30 @@
         }
 
         /// <summary>
-		/// Gets twelve columns from a table and returns an array with the given selector.
-		/// </summary>
-		/// <typeparam name="T1">Type of the first Column.</typeparam>
-		/// <typeparam name="T2">Type of the second Column.</typeparam>
-		/// <typeparam name="T3">Type of the third Column.</typeparam>
-		/// <typeparam name="T4">Type of the fourth Column.</typeparam>
-		/// <typeparam name="T5">Type of the fifth Column.</typeparam>
-		/// <typeparam name="T6">Type of the sixth Column.</typeparam>
-		/// <typeparam name="T7">Type of the seventh Column.</typeparam>
-		/// <typeparam name="T8">Type of the eighth Column.</typeparam>
-		/// <typeparam name="T9">Type of the ninth Column.</typeparam>
-		/// <typeparam name="T10">Type of the tenth Column.</typeparam>
-		/// <typeparam name="T11">Type of the eleventh Column.</typeparam>
-		/// <typeparam name="T12">Type of the twelfth Column.</typeparam>
-		/// <typeparam name="TReturn">Type of the return value.</typeparam>
-		/// <param name="protocol">Link with SLProtocol process.</param>
-		/// <param name="tableId">Id of the table to fetch the columns from.</param>
-		/// <param name="columnIndices">Array with the Columns Indexes.</param>
-		/// <param name="returnSelector">A function to map each column element to a return element.</param>
-		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+        /// Gets twelve columns from a table and returns an array with the given selector.
+        /// </summary>
+        /// <typeparam name="T1">Type of the first Column.</typeparam>
+        /// <typeparam name="T2">Type of the second Column.</typeparam>
+        /// <typeparam name="T3">Type of the third Column.</typeparam>
+        /// <typeparam name="T4">Type of the fourth Column.</typeparam>
+        /// <typeparam name="T5">Type of the fifth Column.</typeparam>
+        /// <typeparam name="T6">Type of the sixth Column.</typeparam>
+        /// <typeparam name="T7">Type of the seventh Column.</typeparam>
+        /// <typeparam name="T8">Type of the eighth Column.</typeparam>
+        /// <typeparam name="T9">Type of the ninth Column.</typeparam>
+        /// <typeparam name="T10">Type of the tenth Column.</typeparam>
+        /// <typeparam name="T11">Type of the eleventh Column.</typeparam>
+        /// <typeparam name="T12">Type of the twelfth Column.</typeparam>
+        /// <typeparam name="TReturn">Type of the return value.</typeparam>
+        /// <param name="protocol">Link with SLProtocol process.</param>
+        /// <param name="tableId">Id of the table to fetch the columns from.</param>
+        /// <param name="columnIndices">Array with the Columns Indexes.</param>
+        /// <param name="returnSelector">A function to map each column element to a return element.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="columnIndices"/> or <paramref name="returnSelector"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">
-		/// Number of columns doesn't match the number of returned members.
-		/// </exception>
+        /// Number of columns doesn't match the number of returned members.
+        /// </exception>
         /// <exception cref="InvalidOperationException">Thrown if the returned data is null, not in the expected format, or contains inconsistent row counts across columns.</exception>
         public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TReturn> returnSelector)
@@ -667,31 +667,31 @@
         }
 
         /// <summary>
-		/// Gets thirteen columns from a table and returns an array with the given selector.
-		/// </summary>
-		/// <typeparam name="T1">Type of the first Column.</typeparam>
-		/// <typeparam name="T2">Type of the second Column.</typeparam>
-		/// <typeparam name="T3">Type of the third Column.</typeparam>
-		/// <typeparam name="T4">Type of the fourth Column.</typeparam>
-		/// <typeparam name="T5">Type of the fifth Column.</typeparam>
-		/// <typeparam name="T6">Type of the sixth Column.</typeparam>
-		/// <typeparam name="T7">Type of the seventh Column.</typeparam>
-		/// <typeparam name="T8">Type of the eighth Column.</typeparam>
-		/// <typeparam name="T9">Type of the ninth Column.</typeparam>
-		/// <typeparam name="T10">Type of the tenth Column.</typeparam>
-		/// <typeparam name="T11">Type of the eleventh Column.</typeparam>
-		/// <typeparam name="T12">Type of the twelfth Column.</typeparam>
-		/// <typeparam name="T13">Type of the thirteenth Column.</typeparam>
-		/// <typeparam name="TReturn">Type of the return value.</typeparam>
+        /// Gets thirteen columns from a table and returns an array with the given selector.
+        /// </summary>
+        /// <typeparam name="T1">Type of the first Column.</typeparam>
+        /// <typeparam name="T2">Type of the second Column.</typeparam>
+        /// <typeparam name="T3">Type of the third Column.</typeparam>
+        /// <typeparam name="T4">Type of the fourth Column.</typeparam>
+        /// <typeparam name="T5">Type of the fifth Column.</typeparam>
+        /// <typeparam name="T6">Type of the sixth Column.</typeparam>
+        /// <typeparam name="T7">Type of the seventh Column.</typeparam>
+        /// <typeparam name="T8">Type of the eighth Column.</typeparam>
+        /// <typeparam name="T9">Type of the ninth Column.</typeparam>
+        /// <typeparam name="T10">Type of the tenth Column.</typeparam>
+        /// <typeparam name="T11">Type of the eleventh Column.</typeparam>
+        /// <typeparam name="T12">Type of the twelfth Column.</typeparam>
+        /// <typeparam name="T13">Type of the thirteenth Column.</typeparam>
+        /// <typeparam name="TReturn">Type of the return value.</typeparam>
         /// <param name="protocol">Link with SLProtocol process.</param>
-		/// <param name="tableId">Id of the table to fetch the columns from.</param>
-		/// <param name="columnIndices">Array with the Columns Indexes.</param>
-		/// <param name="returnSelector">A function to map each column element to a return element.</param>
-		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+        /// <param name="tableId">Id of the table to fetch the columns from.</param>
+        /// <param name="columnIndices">Array with the Columns Indexes.</param>
+        /// <param name="returnSelector">A function to map each column element to a return element.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="columnIndices"/> or <paramref name="returnSelector"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">
-		/// Number of columns doesn't match the number of returned members.
-		/// </exception>
+        /// Number of columns doesn't match the number of returned members.
+        /// </exception>
         /// <exception cref="InvalidOperationException">Thrown if the returned data is null, not in the expected format, or contains inconsistent row counts across columns.</exception>
         public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TReturn> returnSelector)
@@ -721,32 +721,32 @@
         }
 
         /// <summary>
-		/// Gets fourteen columns from a table and returns an array with the given selector.
-		/// </summary>
-		/// <typeparam name="T1">Type of the first Column.</typeparam>
-		/// <typeparam name="T2">Type of the second Column.</typeparam>
-		/// <typeparam name="T3">Type of the third Column.</typeparam>
-		/// <typeparam name="T4">Type of the fourth Column.</typeparam>
-		/// <typeparam name="T5">Type of the fifth Column.</typeparam>
-		/// <typeparam name="T6">Type of the sixth Column.</typeparam>
-		/// <typeparam name="T7">Type of the seventh Column.</typeparam>
-		/// <typeparam name="T8">Type of the eighth Column.</typeparam>
-		/// <typeparam name="T9">Type of the ninth Column.</typeparam>
-		/// <typeparam name="T10">Type of the tenth Column.</typeparam>
-		/// <typeparam name="T11">Type of the eleventh Column.</typeparam>
-		/// <typeparam name="T12">Type of the twelfth Column.</typeparam>
-		/// <typeparam name="T13">Type of the thirteenth Column.</typeparam>
-		/// <typeparam name="T14">Type of the fourteenth Column.</typeparam>
-		/// <typeparam name="TReturn">Type of the return value.</typeparam>
-		/// <param name="protocol">Link with SLProtocol process.</param>
-		/// <param name="tableId">Id of the table to fetch the columns from.</param>
-		/// <param name="columnIndices">Array with the Columns Indexes.</param>
-		/// <param name="returnSelector">A function to map each column element to a return element.</param>
-		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+        /// Gets fourteen columns from a table and returns an array with the given selector.
+        /// </summary>
+        /// <typeparam name="T1">Type of the first Column.</typeparam>
+        /// <typeparam name="T2">Type of the second Column.</typeparam>
+        /// <typeparam name="T3">Type of the third Column.</typeparam>
+        /// <typeparam name="T4">Type of the fourth Column.</typeparam>
+        /// <typeparam name="T5">Type of the fifth Column.</typeparam>
+        /// <typeparam name="T6">Type of the sixth Column.</typeparam>
+        /// <typeparam name="T7">Type of the seventh Column.</typeparam>
+        /// <typeparam name="T8">Type of the eighth Column.</typeparam>
+        /// <typeparam name="T9">Type of the ninth Column.</typeparam>
+        /// <typeparam name="T10">Type of the tenth Column.</typeparam>
+        /// <typeparam name="T11">Type of the eleventh Column.</typeparam>
+        /// <typeparam name="T12">Type of the twelfth Column.</typeparam>
+        /// <typeparam name="T13">Type of the thirteenth Column.</typeparam>
+        /// <typeparam name="T14">Type of the fourteenth Column.</typeparam>
+        /// <typeparam name="TReturn">Type of the return value.</typeparam>
+        /// <param name="protocol">Link with SLProtocol process.</param>
+        /// <param name="tableId">Id of the table to fetch the columns from.</param>
+        /// <param name="columnIndices">Array with the Columns Indexes.</param>
+        /// <param name="returnSelector">A function to map each column element to a return element.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="columnIndices"/> or <paramref name="returnSelector"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">
-		/// Number of columns doesn't match the number of returned members.
-		/// </exception>
+        /// Number of columns doesn't match the number of returned members.
+        /// </exception>
         /// <exception cref="InvalidOperationException">Thrown if the returned data is null, not in the expected format, or contains inconsistent row counts across columns.</exception>
         public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TReturn> returnSelector)
@@ -777,33 +777,33 @@
         }
 
         /// <summary>
-		/// Gets fifteen columns from a table and returns an array with the given selector.
-		/// </summary>
-		/// <typeparam name="T1">Type of the first Column.</typeparam>
-		/// <typeparam name="T2">Type of the second Column.</typeparam>
-		/// <typeparam name="T3">Type of the third Column.</typeparam>
-		/// <typeparam name="T4">Type of the fourth Column.</typeparam>
-		/// <typeparam name="T5">Type of the fifth Column.</typeparam>
-		/// <typeparam name="T6">Type of the sixth Column.</typeparam>
-		/// <typeparam name="T7">Type of the seventh Column.</typeparam>
-		/// <typeparam name="T8">Type of the eighth Column.</typeparam>
-		/// <typeparam name="T9">Type of the ninth Column.</typeparam>
-		/// <typeparam name="T10">Type of the tenth Column.</typeparam>
-		/// <typeparam name="T11">Type of the eleventh Column.</typeparam>
-		/// <typeparam name="T12">Type of the twelfth Column.</typeparam>
-		/// <typeparam name="T13">Type of the thirteenth Column.</typeparam>
-		/// <typeparam name="T14">Type of the fourteenth Column.</typeparam>
-		/// <typeparam name="T15">Type of the fifteenth Column.</typeparam>
-		/// <typeparam name="TReturn">Type of the return value.</typeparam>
+        /// Gets fifteen columns from a table and returns an array with the given selector.
+        /// </summary>
+        /// <typeparam name="T1">Type of the first Column.</typeparam>
+        /// <typeparam name="T2">Type of the second Column.</typeparam>
+        /// <typeparam name="T3">Type of the third Column.</typeparam>
+        /// <typeparam name="T4">Type of the fourth Column.</typeparam>
+        /// <typeparam name="T5">Type of the fifth Column.</typeparam>
+        /// <typeparam name="T6">Type of the sixth Column.</typeparam>
+        /// <typeparam name="T7">Type of the seventh Column.</typeparam>
+        /// <typeparam name="T8">Type of the eighth Column.</typeparam>
+        /// <typeparam name="T9">Type of the ninth Column.</typeparam>
+        /// <typeparam name="T10">Type of the tenth Column.</typeparam>
+        /// <typeparam name="T11">Type of the eleventh Column.</typeparam>
+        /// <typeparam name="T12">Type of the twelfth Column.</typeparam>
+        /// <typeparam name="T13">Type of the thirteenth Column.</typeparam>
+        /// <typeparam name="T14">Type of the fourteenth Column.</typeparam>
+        /// <typeparam name="T15">Type of the fifteenth Column.</typeparam>
+        /// <typeparam name="TReturn">Type of the return value.</typeparam>
         /// <param name="protocol">Link with SLProtocol process.</param>
-		/// <param name="tableId">Id of the table to fetch the columns from.</param>
-		/// <param name="columnIndices">Array with the Columns Indexes.</param>
-		/// <param name="returnSelector">A function to map each column element to a return element.</param>
-		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+        /// <param name="tableId">Id of the table to fetch the columns from.</param>
+        /// <param name="columnIndices">Array with the Columns Indexes.</param>
+        /// <param name="returnSelector">A function to map each column element to a return element.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="columnIndices"/> or <paramref name="returnSelector"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">
-		/// Number of columns doesn't match the number of returned members.
-		/// </exception>
+        /// Number of columns doesn't match the number of returned members.
+        /// </exception>
         /// <exception cref="InvalidOperationException">Thrown if the returned data is null, not in the expected format, or contains inconsistent row counts across columns.</exception>
         public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TReturn> returnSelector)
@@ -835,34 +835,34 @@
         }
 
         /// <summary>
-		/// Gets sixteen columns from a table and returns an array with the given selector.
-		/// </summary>
-		/// <typeparam name="T1">Type of the first Column.</typeparam>
-		/// <typeparam name="T2">Type of the second Column.</typeparam>
-		/// <typeparam name="T3">Type of the third Column.</typeparam>
-		/// <typeparam name="T4">Type of the fourth Column.</typeparam>
-		/// <typeparam name="T5">Type of the fifth Column.</typeparam>
-		/// <typeparam name="T6">Type of the sixth Column.</typeparam>
-		/// <typeparam name="T7">Type of the seventh Column.</typeparam>
-		/// <typeparam name="T8">Type of the eighth Column.</typeparam>
-		/// <typeparam name="T9">Type of the ninth Column.</typeparam>
-		/// <typeparam name="T10">Type of the tenth Column.</typeparam>
-		/// <typeparam name="T11">Type of the eleventh Column.</typeparam>
-		/// <typeparam name="T12">Type of the twelfth Column.</typeparam>
-		/// <typeparam name="T13">Type of the thirteenth Column.</typeparam>
-		/// <typeparam name="T14">Type of the fourteenth Column.</typeparam>
-		/// <typeparam name="T15">Type of the fifteenth Column.</typeparam>
-		/// <typeparam name="T16">Type of the sixteenth Column.</typeparam>
-		/// <typeparam name="TReturn">Type of the return value.</typeparam>
+        /// Gets sixteen columns from a table and returns an array with the given selector.
+        /// </summary>
+        /// <typeparam name="T1">Type of the first Column.</typeparam>
+        /// <typeparam name="T2">Type of the second Column.</typeparam>
+        /// <typeparam name="T3">Type of the third Column.</typeparam>
+        /// <typeparam name="T4">Type of the fourth Column.</typeparam>
+        /// <typeparam name="T5">Type of the fifth Column.</typeparam>
+        /// <typeparam name="T6">Type of the sixth Column.</typeparam>
+        /// <typeparam name="T7">Type of the seventh Column.</typeparam>
+        /// <typeparam name="T8">Type of the eighth Column.</typeparam>
+        /// <typeparam name="T9">Type of the ninth Column.</typeparam>
+        /// <typeparam name="T10">Type of the tenth Column.</typeparam>
+        /// <typeparam name="T11">Type of the eleventh Column.</typeparam>
+        /// <typeparam name="T12">Type of the twelfth Column.</typeparam>
+        /// <typeparam name="T13">Type of the thirteenth Column.</typeparam>
+        /// <typeparam name="T14">Type of the fourteenth Column.</typeparam>
+        /// <typeparam name="T15">Type of the fifteenth Column.</typeparam>
+        /// <typeparam name="T16">Type of the sixteenth Column.</typeparam>
+        /// <typeparam name="TReturn">Type of the return value.</typeparam>
         /// <param name="protocol">Link with SLProtocol process.</param>
         /// <param name="tableId">Id of the table to fetch the columns from.</param>
-		/// <param name="columnIndices">Array with the Columns Indexes.</param>
-		/// <param name="returnSelector">A function to map each column element to a return element.</param>
-		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+        /// <param name="columnIndices">Array with the Columns Indexes.</param>
+        /// <param name="returnSelector">A function to map each column element to a return element.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="columnIndices"/> or <paramref name="returnSelector"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">
-		/// Number of columns doesn't match the number of returned members.
-		/// </exception>
+        /// Number of columns doesn't match the number of returned members.
+        /// </exception>
         /// <exception cref="InvalidOperationException">Thrown if the returned data is null, not in the expected format, or contains inconsistent row counts across columns.</exception>
         public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TReturn> returnSelector)
@@ -895,12 +895,12 @@
         }
 
         /// <summary>
-		/// Executes a <see cref="SLProtocol.GetParameter(int)"/> and return the value in the desired format.
-		/// </summary>
-		/// <typeparam name="T">Type of the Parameter.</typeparam>
+        /// Executes a <see cref="SLProtocol.GetParameter(int)"/> and return the value in the desired format.
+        /// </summary>
+        /// <typeparam name="T">Type of the Parameter.</typeparam>
         /// <param name="protocol">Link with SLProtocol process.</param>
-		/// <param name="paramId">Id of the parameter to retrieve.</param>
-		/// <returns>The parameter value.</returns>
+        /// <param name="paramId">Id of the parameter to retrieve.</param>
+        /// <returns>The parameter value.</returns>
         /// <exception cref="InvalidOperationException">Thrown if the returned value is null.</exception>
         public static T GetParameter<T>(this SLProtocol protocol, int paramId)
             where T : IConvertible
@@ -913,18 +913,18 @@
         }
 
         /// <summary>
-		/// Gets the desired parameters and converts to the given types.
-		/// </summary>
-		/// <typeparam name="T1">Type of the fist parameter.</typeparam>
-		/// <typeparam name="T2">Type of the second parameter.</typeparam>
+        /// Gets the desired parameters and converts to the given types.
+        /// </summary>
+        /// <typeparam name="T1">Type of the fist parameter.</typeparam>
+        /// <typeparam name="T2">Type of the second parameter.</typeparam>
         /// <param name="protocol">Link with SLProtocol process.</param>
-		/// <param name="paramIds">Array with the ids of the Parameters to fetch.</param>
-		/// <param name="param1">Out variable with the first parameter value.</param>
-		/// <param name="param2">Out variable with the second parameter value.</param>
-		/// <exception cref="ArgumentNullException"><paramref name="paramIds"/> is <see langword="null"/></exception>
-		/// <exception cref="ArgumentOutOfRangeException">
-		/// The length of <paramref name="paramIds"/> differs from the number of out parameters.
-		/// </exception>
+        /// <param name="paramIds">Array with the ids of the Parameters to fetch.</param>
+        /// <param name="param1">Out variable with the first parameter value.</param>
+        /// <param name="param2">Out variable with the second parameter value.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="paramIds"/> is <see langword="null"/></exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The length of <paramref name="paramIds"/> differs from the number of out parameters.
+        /// </exception>
         /// <exception cref="InvalidOperationException">Thrown if the result is null, not in the expected format, or contains null values for any parameter.</exception>
         public static void GetParameters<T1, T2>(this SLProtocol protocol, uint[] paramIds, out T1 param1, out T2 param2)
             where T1 : IConvertible
@@ -1390,12 +1390,12 @@
         }
 
         /* We (PedroD and SimonV) considered different options for columnsValues argument type of SetColumns :
-         *      - object[][]							=> Efficient but not so flexible
-         *      - IEnumerable<IEnumarable<object>>		=> Full flexibility but less efficient
-         *      - IList<IEnumerable<object>>			=> Efficient and seems to bring decent flexibility. However, when actually trying to use it, the flexibility is not there.
+         *      - object[][]                            => Efficient but not so flexible
+         *      - IEnumerable<IEnumarable<object>>      => Full flexibility but less efficient
+         *      - IList<IEnumerable<object>>            => Efficient and seems to bring decent flexibility. However, when actually trying to use it, the flexibility is not there.
          *                                                  For some reason, providing it with a list or so doesn't compile.
          *                                                  Only object[][] works. Has to do with the fact that IList do not supper covariance or contravariance because they need to support both reading and writing.
-         *      - IReadOnlyList<IEnumerable<object>>	=> Efficient and brings decent flexibility.
+         *      - IReadOnlyList<IEnumerable<object>>    => Efficient and brings decent flexibility.
          *                                                  This one works because IReadOnlyList is read-only meaning it can support covariance.
          * 
          *  => We opted for option 4 which seemed like a good middle-ground.
@@ -2152,22 +2152,22 @@
         }
 
         private static IEnumerable<TReturn> GetColumnsIterator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TReturn>(object[] columns, int rowCount, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TReturn> returnSelector)
-    where T1 : IConvertible
-    where T2 : IConvertible
-    where T3 : IConvertible
-    where T4 : IConvertible
-    where T5 : IConvertible
-    where T6 : IConvertible
-    where T7 : IConvertible
-    where T8 : IConvertible
-    where T9 : IConvertible
-    where T10 : IConvertible
-    where T11 : IConvertible
-    where T12 : IConvertible
-    where T13 : IConvertible
-    where T14 : IConvertible
-    where T15 : IConvertible
-    where T16 : IConvertible
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+            where T6 : IConvertible
+            where T7 : IConvertible
+            where T8 : IConvertible
+            where T9 : IConvertible
+            where T10 : IConvertible
+            where T11 : IConvertible
+            where T12 : IConvertible
+            where T13 : IConvertible
+            where T14 : IConvertible
+            where T15 : IConvertible
+            where T16 : IConvertible
         {
             for (var i = 0; i < rowCount; i++)
             {

--- a/Utils.Protocol.Extension/ProtocolExtension.cs
+++ b/Utils.Protocol.Extension/ProtocolExtension.cs
@@ -190,6 +190,1520 @@
         }
 
         /// <summary>
+		/// Gets a column with the desired format.
+		/// </summary>
+		/// <typeparam name="T">Type of the Column.</typeparam>
+        /// <param name="protocol">Link with SLProtocol process.</param>
+		/// <param name="tableId">Id of the table to fetch the column from.</param>
+		/// <param name="columnIdx">Index of the desired column.</param>
+		/// <returns>An <see cref="IEnumerable{T}"/> with the desired column.</returns>
+        public static IEnumerable<T> GetColumn<T>(this SLProtocol protocol, int tableId, uint columnIdx)
+            where T : IConvertible
+        {
+            var column = (object[])((object[])protocol.NotifyProtocol(321, tableId, new[] { columnIdx }))[0];
+
+            for (var i = 0; i < column.Length; i++)
+            {
+                yield return column[i].ChangeType<T>();
+            }
+        }
+
+        /// <summary>
+		/// Gets two columns from a table and returns an array with the given selector.
+		/// </summary>
+		/// <typeparam name="T1">Type of the first Column.</typeparam>
+		/// <typeparam name="T2">Type of the second Column.</typeparam>
+		/// <typeparam name="TReturn">Type of the return value.</typeparam>
+        /// <param name="protocol">Link with SLProtocol process.</param>
+        /// <param name="tableId">Id of the table to fetch the columns from.</param>
+		/// <param name="columnIndices">Array with the Columns Indexes.</param>
+		/// <param name="returnSelector">A function to map each column element to a return element.</param>
+		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// Number of columns doesn't match the number of returned members.
+		/// </exception>
+        public static IEnumerable<TReturn> GetColumns<T1, T2, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices, Func<T1, T2, TReturn> returnSelector)
+            where T1 : IConvertible
+            where T2 : IConvertible
+        {
+            const int columnCount = 2;
+
+            if (columnIndices == null)
+            {
+                throw new ArgumentNullException(nameof(columnIndices));
+            }
+
+            if (returnSelector == null)
+            {
+                throw new ArgumentNullException(nameof(returnSelector));
+            }
+
+            if (columnIndices.Length != columnCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
+            }
+
+            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
+
+            for (var i = 0; i < ((object[])columns[0]).Length; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>());
+            }
+        }
+
+        /// <summary>
+		/// Gets three columns from a table and returns an array with the given selector.
+		/// </summary>
+		/// <typeparam name="T1">Type of the first Column.</typeparam>
+		/// <typeparam name="T2">Type of the second Column.</typeparam>
+		/// <typeparam name="T3">Type of the third Column.</typeparam>
+		/// <typeparam name="TReturn">Type of the return value.</typeparam>
+        /// <param name="protocol">Link with SLProtocol process.</param>
+        /// <param name="tableId">Id of the table to fetch the columns from.</param>
+		/// <param name="columnIndices">Array with the Columns Indexes.</param>
+		/// <param name="returnSelector">A function to map each column element to a return element.</param>
+		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// Number of columns doesn't match the number of returned members.
+		/// </exception>
+        public static IEnumerable<TReturn> GetColumns<T1, T2, T3, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices, Func<T1, T2, T3, TReturn> returnSelector)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+        {
+            const int columnCount = 3;
+
+            if (columnIndices == null)
+            {
+                throw new ArgumentNullException(nameof(columnIndices));
+            }
+
+            if (returnSelector == null)
+            {
+                throw new ArgumentNullException(nameof(returnSelector));
+            }
+
+            if (columnIndices.Length != columnCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
+            }
+
+            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
+
+            for (var i = 0; i < ((object[])columns[0]).Length; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>(),
+                    ((object[])columns[2])[i].ChangeType<T3>());
+            }
+        }
+
+        /// <summary>
+		/// Gets four columns from a table and returns an array with the given selector.
+		/// </summary>
+		/// <typeparam name="T1">Type of the first Column.</typeparam>
+		/// <typeparam name="T2">Type of the second Column.</typeparam>
+		/// <typeparam name="T3">Type of the third Column.</typeparam>
+		/// <typeparam name="T4">Type of the fourth Column.</typeparam>
+		/// <typeparam name="TReturn">Type of the return value.</typeparam>
+        /// <param name="protocol">Link with SLProtocol process.</param>
+        /// <param name="tableId">Id of the table to fetch the columns from.</param>
+		/// <param name="columnIndices">Array with the Columns Indexes.</param>
+		/// <param name="returnSelector">A function to map each column element to a return element.</param>
+		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// Number of columns doesn't match the number of returned members.
+		/// </exception>
+        public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices, Func<T1, T2, T3, T4, TReturn> returnSelector)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+        {
+            const int columnCount = 4;
+
+            if (columnIndices == null)
+            {
+                throw new ArgumentNullException(nameof(columnIndices));
+            }
+
+            if (returnSelector == null)
+            {
+                throw new ArgumentNullException(nameof(returnSelector));
+            }
+
+            if (columnIndices.Length != columnCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
+            }
+
+            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
+
+            for (var i = 0; i < ((object[])columns[0]).Length; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>(),
+                    ((object[])columns[2])[i].ChangeType<T3>(),
+                    ((object[])columns[3])[i].ChangeType<T4>());
+            }
+        }
+
+        /// <summary>
+		/// Gets five columns from a table and returns an array with the given selector.
+		/// </summary>
+		/// <typeparam name="T1">Type of the first Column.</typeparam>
+		/// <typeparam name="T2">Type of the second Column.</typeparam>
+		/// <typeparam name="T3">Type of the third Column.</typeparam>
+		/// <typeparam name="T4">Type of the fourth Column.</typeparam>
+		/// <typeparam name="T5">Type of the fifth Column.</typeparam>
+		/// <typeparam name="TReturn">Type of the return value.</typeparam>
+        /// <param name="protocol">Link with SLProtocol process.</param>
+        /// <param name="tableId">Id of the table to fetch the columns from.</param>
+		/// <param name="columnIndices">Array with the Columns Indexes.</param>
+		/// <param name="returnSelector">A function to map each column element to a return element.</param>
+		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// Number of columns doesn't match the number of returned members.
+		/// </exception>
+        public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices, Func<T1, T2, T3, T4, T5, TReturn> returnSelector)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+        {
+            const int columnCount = 5;
+
+            if (columnIndices == null)
+            {
+                throw new ArgumentNullException(nameof(columnIndices));
+            }
+
+            if (returnSelector == null)
+            {
+                throw new ArgumentNullException(nameof(returnSelector));
+            }
+
+            if (columnIndices.Length != columnCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
+            }
+
+            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
+
+            for (var i = 0; i < ((object[])columns[0]).Length; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>(),
+                    ((object[])columns[2])[i].ChangeType<T3>(),
+                    ((object[])columns[3])[i].ChangeType<T4>(),
+                    ((object[])columns[4])[i].ChangeType<T5>());
+            }
+        }
+
+        /// <summary>
+		/// Gets six columns from a table and returns an array with the given selector.
+		/// </summary>
+		/// <typeparam name="T1">Type of the first Column.</typeparam>
+		/// <typeparam name="T2">Type of the second Column.</typeparam>
+		/// <typeparam name="T3">Type of the third Column.</typeparam>
+		/// <typeparam name="T4">Type of the fourth Column.</typeparam>
+		/// <typeparam name="T5">Type of the fifth Column.</typeparam>
+		/// <typeparam name="T6">Type of the sixth Column.</typeparam>
+		/// <typeparam name="TReturn">Type of the return value.</typeparam>
+        /// <param name="protocol">Link with SLProtocol process.</param>
+        /// <param name="tableId">Id of the table to fetch the columns from.</param>
+		/// <param name="columnIndices">Array with the Columns Indexes.</param>
+		/// <param name="returnSelector">A function to map each column element to a return element.</param>
+		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// Number of columns doesn't match the number of returned members.
+		/// </exception>
+        public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
+            Func<T1, T2, T3, T4, T5, T6, TReturn> returnSelector)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+            where T6 : IConvertible
+        {
+            const int columnCount = 6;
+
+            if (columnIndices == null)
+            {
+                throw new ArgumentNullException(nameof(columnIndices));
+            }
+
+            if (returnSelector == null)
+            {
+                throw new ArgumentNullException(nameof(returnSelector));
+            }
+
+            if (columnIndices.Length != columnCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
+            }
+
+            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
+
+            for (var i = 0; i < ((object[])columns[0]).Length; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>(),
+                    ((object[])columns[2])[i].ChangeType<T3>(),
+                    ((object[])columns[3])[i].ChangeType<T4>(),
+                    ((object[])columns[4])[i].ChangeType<T5>(),
+                    ((object[])columns[5])[i].ChangeType<T6>());
+            }
+        }
+
+        /// <summary>
+		/// Gets seven columns from a table and returns an array with the given selector.
+		/// </summary>
+		/// <typeparam name="T1">Type of the first Column.</typeparam>
+		/// <typeparam name="T2">Type of the second Column.</typeparam>
+		/// <typeparam name="T3">Type of the third Column.</typeparam>
+		/// <typeparam name="T4">Type of the fourth Column.</typeparam>
+		/// <typeparam name="T5">Type of the fifth Column.</typeparam>
+		/// <typeparam name="T6">Type of the sixth Column.</typeparam>
+		/// <typeparam name="T7">Type of the seventh Column.</typeparam>
+		/// <typeparam name="TReturn">Type of the return value.</typeparam>
+        /// <param name="protocol">Link with SLProtocol process.</param>
+        /// <param name="tableId">Id of the table to fetch the columns from.</param>
+		/// <param name="columnIndices">Array with the Columns Indexes.</param>
+		/// <param name="returnSelector">A function to map each column element to a return element.</param>
+		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// Number of columns doesn't match the number of returned members.
+		/// </exception>
+        public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, T7, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
+            Func<T1, T2, T3, T4, T5, T6, T7, TReturn> returnSelector)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+            where T6 : IConvertible
+            where T7 : IConvertible
+        {
+            const int columnCount = 7;
+
+            if (columnIndices == null)
+            {
+                throw new ArgumentNullException(nameof(columnIndices));
+            }
+
+            if (returnSelector == null)
+            {
+                throw new ArgumentNullException(nameof(returnSelector));
+            }
+
+            if (columnIndices.Length != columnCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
+            }
+
+            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
+
+            for (var i = 0; i < ((object[])columns[0]).Length; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>(),
+                    ((object[])columns[2])[i].ChangeType<T3>(),
+                    ((object[])columns[3])[i].ChangeType<T4>(),
+                    ((object[])columns[4])[i].ChangeType<T5>(),
+                    ((object[])columns[5])[i].ChangeType<T6>(),
+                    ((object[])columns[6])[i].ChangeType<T7>());
+            }
+        }
+
+        /// <summary>
+		/// Gets eight columns from a table and returns an array with the given selector.
+		/// </summary>
+		/// <typeparam name="T1">Type of the first Column.</typeparam>
+		/// <typeparam name="T2">Type of the second Column.</typeparam>
+		/// <typeparam name="T3">Type of the third Column.</typeparam>
+		/// <typeparam name="T4">Type of the fourth Column.</typeparam>
+		/// <typeparam name="T5">Type of the fifth Column.</typeparam>
+		/// <typeparam name="T6">Type of the sixth Column.</typeparam>
+		/// <typeparam name="T7">Type of the seventh Column.</typeparam>
+		/// <typeparam name="T8">Type of the eighth Column.</typeparam>
+		/// <typeparam name="TReturn">Type of the return value.</typeparam>
+        /// <param name="protocol">Link with SLProtocol process.</param>
+        /// <param name="tableId">Id of the table to fetch the columns from.</param>
+		/// <param name="columnIndices">Array with the Columns Indexes.</param>
+		/// <param name="returnSelector">A function to map each column element to a return element.</param>
+		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// Number of columns doesn't match the number of returned members.
+		/// </exception>
+        public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, T7, T8, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, TReturn> returnSelector)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+            where T6 : IConvertible
+            where T7 : IConvertible
+            where T8 : IConvertible
+        {
+            const int columnCount = 8;
+
+            if (columnIndices == null)
+            {
+                throw new ArgumentNullException(nameof(columnIndices));
+            }
+
+            if (returnSelector == null)
+            {
+                throw new ArgumentNullException(nameof(returnSelector));
+            }
+
+            if (columnIndices.Length != columnCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
+            }
+
+            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
+
+            for (var i = 0; i < ((object[])columns[0]).Length; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>(),
+                    ((object[])columns[2])[i].ChangeType<T3>(),
+                    ((object[])columns[3])[i].ChangeType<T4>(),
+                    ((object[])columns[4])[i].ChangeType<T5>(),
+                    ((object[])columns[5])[i].ChangeType<T6>(),
+                    ((object[])columns[6])[i].ChangeType<T7>(),
+                    ((object[])columns[7])[i].ChangeType<T8>());
+            }
+        }
+
+        /// <summary>
+		/// Gets nine columns from a table and returns an array with the given selector.
+		/// </summary>
+		/// <typeparam name="T1">Type of the first Column.</typeparam>
+		/// <typeparam name="T2">Type of the second Column.</typeparam>
+		/// <typeparam name="T3">Type of the third Column.</typeparam>
+		/// <typeparam name="T4">Type of the fourth Column.</typeparam>
+		/// <typeparam name="T5">Type of the fifth Column.</typeparam>
+		/// <typeparam name="T6">Type of the sixth Column.</typeparam>
+		/// <typeparam name="T7">Type of the seventh Column.</typeparam>
+		/// <typeparam name="T8">Type of the eighth Column.</typeparam>
+		/// <typeparam name="T9">Type of the ninth Column.</typeparam>
+		/// <typeparam name="TReturn">Type of the return value.</typeparam>
+        /// <param name="protocol">Link with SLProtocol process.</param>
+		/// <param name="tableId">Id of the table to fetch the columns from.</param>
+		/// <param name="columnIndices">Array with the Columns Indexes.</param>
+		/// <param name="returnSelector">A function to map each column element to a return element.</param>
+		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// Number of columns doesn't match the number of returned members.
+		/// </exception>
+        public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, T7, T8, T9, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TReturn> returnSelector)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+            where T6 : IConvertible
+            where T7 : IConvertible
+            where T8 : IConvertible
+            where T9 : IConvertible
+        {
+            const int columnCount = 9;
+
+            if (columnIndices == null)
+            {
+                throw new ArgumentNullException(nameof(columnIndices));
+            }
+
+            if (returnSelector == null)
+            {
+                throw new ArgumentNullException(nameof(returnSelector));
+            }
+
+            if (columnIndices.Length != columnCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
+            }
+
+            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
+
+            for (var i = 0; i < ((object[])columns[0]).Length; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>(),
+                    ((object[])columns[2])[i].ChangeType<T3>(),
+                    ((object[])columns[3])[i].ChangeType<T4>(),
+                    ((object[])columns[4])[i].ChangeType<T5>(),
+                    ((object[])columns[5])[i].ChangeType<T6>(),
+                    ((object[])columns[6])[i].ChangeType<T7>(),
+                    ((object[])columns[7])[i].ChangeType<T8>(),
+                    ((object[])columns[8])[i].ChangeType<T9>());
+            }
+        }
+
+        /// <summary>
+		/// Gets ten columns from a table and returns an array with the given selector.
+		/// </summary>
+		/// <typeparam name="T1">Type of the first Column.</typeparam>
+		/// <typeparam name="T2">Type of the second Column.</typeparam>
+		/// <typeparam name="T3">Type of the third Column.</typeparam>
+		/// <typeparam name="T4">Type of the fourth Column.</typeparam>
+		/// <typeparam name="T5">Type of the fifth Column.</typeparam>
+		/// <typeparam name="T6">Type of the sixth Column.</typeparam>
+		/// <typeparam name="T7">Type of the seventh Column.</typeparam>
+		/// <typeparam name="T8">Type of the eighth Column.</typeparam>
+		/// <typeparam name="T9">Type of the ninth Column.</typeparam>
+		/// <typeparam name="T10">Type of the tenth Column.</typeparam>
+		/// <typeparam name="TReturn">Type of the return value.</typeparam>
+		/// <param name="protocol">Link with SLProtocol process.</param>
+		/// <param name="tableId">Id of the table to fetch the columns from.</param>
+		/// <param name="columnIndices">Array with the Columns Indexes.</param>
+		/// <param name="returnSelector">A function to map each column element to a return element.</param>
+		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// Number of columns doesn't match the number of returned members.
+		/// </exception>
+        public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TReturn> returnSelector)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+            where T6 : IConvertible
+            where T7 : IConvertible
+            where T8 : IConvertible
+            where T9 : IConvertible
+            where T10 : IConvertible
+        {
+            const int columnCount = 10;
+
+            if (columnIndices == null)
+            {
+                throw new ArgumentNullException(nameof(columnIndices));
+            }
+
+            if (returnSelector == null)
+            {
+                throw new ArgumentNullException(nameof(returnSelector));
+            }
+
+            if (columnIndices.Length != columnCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
+            }
+
+            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
+
+            for (var i = 0; i < ((object[])columns[0]).Length; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>(),
+                    ((object[])columns[2])[i].ChangeType<T3>(),
+                    ((object[])columns[3])[i].ChangeType<T4>(),
+                    ((object[])columns[4])[i].ChangeType<T5>(),
+                    ((object[])columns[5])[i].ChangeType<T6>(),
+                    ((object[])columns[6])[i].ChangeType<T7>(),
+                    ((object[])columns[7])[i].ChangeType<T8>(),
+                    ((object[])columns[8])[i].ChangeType<T9>(),
+                    ((object[])columns[9])[i].ChangeType<T10>());
+            }
+        }
+
+        /// <summary>
+		/// Gets eleven columns from a table and returns an array with the given selector.
+		/// </summary>
+		/// <typeparam name="T1">Type of the first Column.</typeparam>
+		/// <typeparam name="T2">Type of the second Column.</typeparam>
+		/// <typeparam name="T3">Type of the third Column.</typeparam>
+		/// <typeparam name="T4">Type of the fourth Column.</typeparam>
+		/// <typeparam name="T5">Type of the fifth Column.</typeparam>
+		/// <typeparam name="T6">Type of the sixth Column.</typeparam>
+		/// <typeparam name="T7">Type of the seventh Column.</typeparam>
+		/// <typeparam name="T8">Type of the eighth Column.</typeparam>
+		/// <typeparam name="T9">Type of the ninth Column.</typeparam>
+		/// <typeparam name="T10">Type of the tenth Column.</typeparam>
+		/// <typeparam name="T11">Type of the eleventh Column.</typeparam>
+		/// <typeparam name="TReturn">Type of the return value.</typeparam>
+        /// <param name="protocol">Link with SLProtocol process.</param>
+		/// <param name="tableId">Id of the table to fetch the columns from.</param>
+		/// <param name="columnIndices">Array with the Columns Indexes.</param>
+		/// <param name="returnSelector">A function to map each column element to a return element.</param>
+		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// Number of columns doesn't match the number of returned members.
+		/// </exception>
+        public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TReturn> returnSelector)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+            where T6 : IConvertible
+            where T7 : IConvertible
+            where T8 : IConvertible
+            where T9 : IConvertible
+            where T10 : IConvertible
+            where T11 : IConvertible
+        {
+            const int columnCount = 11;
+
+            if (columnIndices == null)
+            {
+                throw new ArgumentNullException(nameof(columnIndices));
+            }
+
+            if (returnSelector == null)
+            {
+                throw new ArgumentNullException(nameof(returnSelector));
+            }
+
+            if (columnIndices.Length != columnCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
+            }
+
+            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
+
+            for (var i = 0; i < ((object[])columns[0]).Length; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>(),
+                    ((object[])columns[2])[i].ChangeType<T3>(),
+                    ((object[])columns[3])[i].ChangeType<T4>(),
+                    ((object[])columns[4])[i].ChangeType<T5>(),
+                    ((object[])columns[5])[i].ChangeType<T6>(),
+                    ((object[])columns[6])[i].ChangeType<T7>(),
+                    ((object[])columns[7])[i].ChangeType<T8>(),
+                    ((object[])columns[8])[i].ChangeType<T9>(),
+                    ((object[])columns[9])[i].ChangeType<T10>(),
+                    ((object[])columns[10])[i].ChangeType<T11>());
+            }
+        }
+
+        /// <summary>
+		/// Gets twelve columns from a table and returns an array with the given selector.
+		/// </summary>
+		/// <typeparam name="T1">Type of the first Column.</typeparam>
+		/// <typeparam name="T2">Type of the second Column.</typeparam>
+		/// <typeparam name="T3">Type of the third Column.</typeparam>
+		/// <typeparam name="T4">Type of the fourth Column.</typeparam>
+		/// <typeparam name="T5">Type of the fifth Column.</typeparam>
+		/// <typeparam name="T6">Type of the sixth Column.</typeparam>
+		/// <typeparam name="T7">Type of the seventh Column.</typeparam>
+		/// <typeparam name="T8">Type of the eighth Column.</typeparam>
+		/// <typeparam name="T9">Type of the ninth Column.</typeparam>
+		/// <typeparam name="T10">Type of the tenth Column.</typeparam>
+		/// <typeparam name="T11">Type of the eleventh Column.</typeparam>
+		/// <typeparam name="T12">Type of the twelfth Column.</typeparam>
+		/// <typeparam name="TReturn">Type of the return value.</typeparam>
+		/// <param name="protocol">Link with SLProtocol process.</param>
+		/// <param name="tableId">Id of the table to fetch the columns from.</param>
+		/// <param name="columnIndices">Array with the Columns Indexes.</param>
+		/// <param name="returnSelector">A function to map each column element to a return element.</param>
+		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// Number of columns doesn't match the number of returned members.
+		/// </exception>
+        public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TReturn> returnSelector)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+            where T6 : IConvertible
+            where T7 : IConvertible
+            where T8 : IConvertible
+            where T9 : IConvertible
+            where T10 : IConvertible
+            where T11 : IConvertible
+            where T12 : IConvertible
+        {
+            const int columnCount = 12;
+
+            if (columnIndices == null)
+            {
+                throw new ArgumentNullException(nameof(columnIndices));
+            }
+
+            if (returnSelector == null)
+            {
+                throw new ArgumentNullException(nameof(returnSelector));
+            }
+
+            if (columnIndices.Length != columnCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
+            }
+
+            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
+
+            for (var i = 0; i < ((object[])columns[0]).Length; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>(),
+                    ((object[])columns[2])[i].ChangeType<T3>(),
+                    ((object[])columns[3])[i].ChangeType<T4>(),
+                    ((object[])columns[4])[i].ChangeType<T5>(),
+                    ((object[])columns[5])[i].ChangeType<T6>(),
+                    ((object[])columns[6])[i].ChangeType<T7>(),
+                    ((object[])columns[7])[i].ChangeType<T8>(),
+                    ((object[])columns[8])[i].ChangeType<T9>(),
+                    ((object[])columns[9])[i].ChangeType<T10>(),
+                    ((object[])columns[10])[i].ChangeType<T11>(),
+                    ((object[])columns[11])[i].ChangeType<T12>());
+            }
+        }
+
+        /// <summary>
+		/// Gets thirteen columns from a table and returns an array with the given selector.
+		/// </summary>
+		/// <typeparam name="T1">Type of the first Column.</typeparam>
+		/// <typeparam name="T2">Type of the second Column.</typeparam>
+		/// <typeparam name="T3">Type of the third Column.</typeparam>
+		/// <typeparam name="T4">Type of the fourth Column.</typeparam>
+		/// <typeparam name="T5">Type of the fifth Column.</typeparam>
+		/// <typeparam name="T6">Type of the sixth Column.</typeparam>
+		/// <typeparam name="T7">Type of the seventh Column.</typeparam>
+		/// <typeparam name="T8">Type of the eighth Column.</typeparam>
+		/// <typeparam name="T9">Type of the ninth Column.</typeparam>
+		/// <typeparam name="T10">Type of the tenth Column.</typeparam>
+		/// <typeparam name="T11">Type of the eleventh Column.</typeparam>
+		/// <typeparam name="T12">Type of the twelfth Column.</typeparam>
+		/// <typeparam name="T13">Type of the thirteenth Column.</typeparam>
+		/// <typeparam name="TReturn">Type of the return value.</typeparam>
+        /// <param name="protocol">Link with SLProtocol process.</param>
+		/// <param name="tableId">Id of the table to fetch the columns from.</param>
+		/// <param name="columnIndices">Array with the Columns Indexes.</param>
+		/// <param name="returnSelector">A function to map each column element to a return element.</param>
+		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// Number of columns doesn't match the number of returned members.
+		/// </exception>
+        public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TReturn> returnSelector)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+            where T6 : IConvertible
+            where T7 : IConvertible
+            where T8 : IConvertible
+            where T9 : IConvertible
+            where T10 : IConvertible
+            where T11 : IConvertible
+            where T12 : IConvertible
+            where T13 : IConvertible
+        {
+            const int columnCount = 13;
+
+            if (columnIndices == null)
+            {
+                throw new ArgumentNullException(nameof(columnIndices));
+            }
+
+            if (returnSelector == null)
+            {
+                throw new ArgumentNullException(nameof(returnSelector));
+            }
+
+            if (columnIndices.Length != columnCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
+            }
+
+            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
+
+            for (var i = 0; i < ((object[])columns[0]).Length; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>(),
+                    ((object[])columns[2])[i].ChangeType<T3>(),
+                    ((object[])columns[3])[i].ChangeType<T4>(),
+                    ((object[])columns[4])[i].ChangeType<T5>(),
+                    ((object[])columns[5])[i].ChangeType<T6>(),
+                    ((object[])columns[6])[i].ChangeType<T7>(),
+                    ((object[])columns[7])[i].ChangeType<T8>(),
+                    ((object[])columns[8])[i].ChangeType<T9>(),
+                    ((object[])columns[9])[i].ChangeType<T10>(),
+                    ((object[])columns[10])[i].ChangeType<T11>(),
+                    ((object[])columns[11])[i].ChangeType<T12>(),
+                    ((object[])columns[12])[i].ChangeType<T13>());
+            }
+        }
+
+        /// <summary>
+		/// Gets fourteen columns from a table and returns an array with the given selector.
+		/// </summary>
+		/// <typeparam name="T1">Type of the first Column.</typeparam>
+		/// <typeparam name="T2">Type of the second Column.</typeparam>
+		/// <typeparam name="T3">Type of the third Column.</typeparam>
+		/// <typeparam name="T4">Type of the fourth Column.</typeparam>
+		/// <typeparam name="T5">Type of the fifth Column.</typeparam>
+		/// <typeparam name="T6">Type of the sixth Column.</typeparam>
+		/// <typeparam name="T7">Type of the seventh Column.</typeparam>
+		/// <typeparam name="T8">Type of the eighth Column.</typeparam>
+		/// <typeparam name="T9">Type of the ninth Column.</typeparam>
+		/// <typeparam name="T10">Type of the tenth Column.</typeparam>
+		/// <typeparam name="T11">Type of the eleventh Column.</typeparam>
+		/// <typeparam name="T12">Type of the twelfth Column.</typeparam>
+		/// <typeparam name="T13">Type of the thirteenth Column.</typeparam>
+		/// <typeparam name="T14">Type of the fourteenth Column.</typeparam>
+		/// <typeparam name="TReturn">Type of the return value.</typeparam>
+		/// <param name="protocol">Link with SLProtocol process.</param>
+		/// <param name="tableId">Id of the table to fetch the columns from.</param>
+		/// <param name="columnIndices">Array with the Columns Indexes.</param>
+		/// <param name="returnSelector">A function to map each column element to a return element.</param>
+		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// Number of columns doesn't match the number of returned members.
+		/// </exception>
+        public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TReturn> returnSelector)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+            where T6 : IConvertible
+            where T7 : IConvertible
+            where T8 : IConvertible
+            where T9 : IConvertible
+            where T10 : IConvertible
+            where T11 : IConvertible
+            where T12 : IConvertible
+            where T13 : IConvertible
+            where T14 : IConvertible
+        {
+            const int columnCount = 14;
+
+            if (columnIndices == null)
+            {
+                throw new ArgumentNullException(nameof(columnIndices));
+            }
+
+            if (returnSelector == null)
+            {
+                throw new ArgumentNullException(nameof(returnSelector));
+            }
+
+            if (columnIndices.Length != columnCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
+            }
+
+            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
+
+            for (var i = 0; i < ((object[])columns[0]).Length; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>(),
+                    ((object[])columns[2])[i].ChangeType<T3>(),
+                    ((object[])columns[3])[i].ChangeType<T4>(),
+                    ((object[])columns[4])[i].ChangeType<T5>(),
+                    ((object[])columns[5])[i].ChangeType<T6>(),
+                    ((object[])columns[6])[i].ChangeType<T7>(),
+                    ((object[])columns[7])[i].ChangeType<T8>(),
+                    ((object[])columns[8])[i].ChangeType<T9>(),
+                    ((object[])columns[9])[i].ChangeType<T10>(),
+                    ((object[])columns[10])[i].ChangeType<T11>(),
+                    ((object[])columns[11])[i].ChangeType<T12>(),
+                    ((object[])columns[12])[i].ChangeType<T13>(),
+                    ((object[])columns[13])[i].ChangeType<T14>());
+            }
+        }
+
+        /// <summary>
+		/// Gets fifteen columns from a table and returns an array with the given selector.
+		/// </summary>
+		/// <typeparam name="T1">Type of the first Column.</typeparam>
+		/// <typeparam name="T2">Type of the second Column.</typeparam>
+		/// <typeparam name="T3">Type of the third Column.</typeparam>
+		/// <typeparam name="T4">Type of the fourth Column.</typeparam>
+		/// <typeparam name="T5">Type of the fifth Column.</typeparam>
+		/// <typeparam name="T6">Type of the sixth Column.</typeparam>
+		/// <typeparam name="T7">Type of the seventh Column.</typeparam>
+		/// <typeparam name="T8">Type of the eighth Column.</typeparam>
+		/// <typeparam name="T9">Type of the ninth Column.</typeparam>
+		/// <typeparam name="T10">Type of the tenth Column.</typeparam>
+		/// <typeparam name="T11">Type of the eleventh Column.</typeparam>
+		/// <typeparam name="T12">Type of the twelfth Column.</typeparam>
+		/// <typeparam name="T13">Type of the thirteenth Column.</typeparam>
+		/// <typeparam name="T14">Type of the fourteenth Column.</typeparam>
+		/// <typeparam name="T15">Type of the fifteenth Column.</typeparam>
+		/// <typeparam name="TReturn">Type of the return value.</typeparam>
+        /// <param name="protocol">Link with SLProtocol process.</param>
+		/// <param name="tableId">Id of the table to fetch the columns from.</param>
+		/// <param name="columnIndices">Array with the Columns Indexes.</param>
+		/// <param name="returnSelector">A function to map each column element to a return element.</param>
+		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// Number of columns doesn't match the number of returned members.
+		/// </exception>
+        public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TReturn> returnSelector)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+            where T6 : IConvertible
+            where T7 : IConvertible
+            where T8 : IConvertible
+            where T9 : IConvertible
+            where T10 : IConvertible
+            where T11 : IConvertible
+            where T12 : IConvertible
+            where T13 : IConvertible
+            where T14 : IConvertible
+            where T15 : IConvertible
+        {
+            const int columnCount = 15;
+
+            if (columnIndices == null)
+            {
+                throw new ArgumentNullException(nameof(columnIndices));
+            }
+
+            if (returnSelector == null)
+            {
+                throw new ArgumentNullException(nameof(returnSelector));
+            }
+
+            if (columnIndices.Length != columnCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
+            }
+
+            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
+
+            for (var i = 0; i < ((object[])columns[0]).Length; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>(),
+                    ((object[])columns[2])[i].ChangeType<T3>(),
+                    ((object[])columns[3])[i].ChangeType<T4>(),
+                    ((object[])columns[4])[i].ChangeType<T5>(),
+                    ((object[])columns[5])[i].ChangeType<T6>(),
+                    ((object[])columns[6])[i].ChangeType<T7>(),
+                    ((object[])columns[7])[i].ChangeType<T8>(),
+                    ((object[])columns[8])[i].ChangeType<T9>(),
+                    ((object[])columns[9])[i].ChangeType<T10>(),
+                    ((object[])columns[10])[i].ChangeType<T11>(),
+                    ((object[])columns[11])[i].ChangeType<T12>(),
+                    ((object[])columns[12])[i].ChangeType<T13>(),
+                    ((object[])columns[13])[i].ChangeType<T14>(),
+                    ((object[])columns[14])[i].ChangeType<T15>());
+            }
+        }
+
+        /// <summary>
+		/// Gets sixteen columns from a table and returns an array with the given selector.
+		/// </summary>
+		/// <typeparam name="T1">Type of the first Column.</typeparam>
+		/// <typeparam name="T2">Type of the second Column.</typeparam>
+		/// <typeparam name="T3">Type of the third Column.</typeparam>
+		/// <typeparam name="T4">Type of the fourth Column.</typeparam>
+		/// <typeparam name="T5">Type of the fifth Column.</typeparam>
+		/// <typeparam name="T6">Type of the sixth Column.</typeparam>
+		/// <typeparam name="T7">Type of the seventh Column.</typeparam>
+		/// <typeparam name="T8">Type of the eighth Column.</typeparam>
+		/// <typeparam name="T9">Type of the ninth Column.</typeparam>
+		/// <typeparam name="T10">Type of the tenth Column.</typeparam>
+		/// <typeparam name="T11">Type of the eleventh Column.</typeparam>
+		/// <typeparam name="T12">Type of the twelfth Column.</typeparam>
+		/// <typeparam name="T13">Type of the thirteenth Column.</typeparam>
+		/// <typeparam name="T14">Type of the fourteenth Column.</typeparam>
+		/// <typeparam name="T15">Type of the fifteenth Column.</typeparam>
+		/// <typeparam name="T16">Type of the sixteenth Column.</typeparam>
+		/// <typeparam name="TReturn">Type of the return value.</typeparam>
+        /// <param name="protocol">Link with SLProtocol process.</param>
+        /// <param name="tableId">Id of the table to fetch the columns from.</param>
+		/// <param name="columnIndices">Array with the Columns Indexes.</param>
+		/// <param name="returnSelector">A function to map each column element to a return element.</param>
+		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// Number of columns doesn't match the number of returned members.
+		/// </exception>
+        public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TReturn> returnSelector)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+            where T6 : IConvertible
+            where T7 : IConvertible
+            where T8 : IConvertible
+            where T9 : IConvertible
+            where T10 : IConvertible
+            where T11 : IConvertible
+            where T12 : IConvertible
+            where T13 : IConvertible
+            where T14 : IConvertible
+            where T15 : IConvertible
+            where T16 : IConvertible
+        {
+            const int columnCount = 16;
+
+            if (columnIndices == null)
+            {
+                throw new ArgumentNullException(nameof(columnIndices));
+            }
+
+            if (returnSelector == null)
+            {
+                throw new ArgumentNullException(nameof(returnSelector));
+            }
+
+            if (columnIndices.Length != columnCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
+            }
+
+            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
+
+            for (var i = 0; i < ((object[])columns[0]).Length; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>(),
+                    ((object[])columns[2])[i].ChangeType<T3>(),
+                    ((object[])columns[3])[i].ChangeType<T4>(),
+                    ((object[])columns[4])[i].ChangeType<T5>(),
+                    ((object[])columns[5])[i].ChangeType<T6>(),
+                    ((object[])columns[6])[i].ChangeType<T7>(),
+                    ((object[])columns[7])[i].ChangeType<T8>(),
+                    ((object[])columns[8])[i].ChangeType<T9>(),
+                    ((object[])columns[9])[i].ChangeType<T10>(),
+                    ((object[])columns[10])[i].ChangeType<T11>(),
+                    ((object[])columns[11])[i].ChangeType<T12>(),
+                    ((object[])columns[12])[i].ChangeType<T13>(),
+                    ((object[])columns[13])[i].ChangeType<T14>(),
+                    ((object[])columns[14])[i].ChangeType<T15>(),
+                    ((object[])columns[15])[i].ChangeType<T16>());
+            }
+        }
+
+        /// <summary>
+		/// Executes a <see cref="SLProtocol.GetParameter(int)"/> and return the value in the desired format.
+		/// </summary>
+		/// <typeparam name="T">Type of the Parameter.</typeparam>
+        /// <param name="protocol">Link with SLProtocol process.</param>
+		/// <param name="paramId">Id of the parameter to retrieve.</param>
+		/// <returns>The parameter value.</returns>
+        public static T GetParameter<T>(this SLProtocol protocol, int paramId)
+            where T : IConvertible
+        {
+            return protocol.GetParameter(paramId).ChangeType<T>();
+        }
+
+        /// <summary>
+		/// Gets the desired parameters and converts to the given types.
+		/// </summary>
+		/// <typeparam name="T1">Type of the fist parameter.</typeparam>
+		/// <typeparam name="T2">Type of the second parameter.</typeparam>
+        /// <param name="protocol">Link with SLProtocol process.</param>
+		/// <param name="paramIds">Array with the ids of the Parameters to fetch.</param>
+		/// <param name="param1">Out variable with the first parameter value.</param>
+		/// <param name="param2">Out variable with the second parameter value.</param>
+		/// <exception cref="ArgumentNullException"><paramref name="paramIds"/> is <see langword="null"/></exception>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// The length of <paramref name="paramIds"/> differs from the number of out parameters.
+		/// </exception>
+        public static void GetParameters<T1, T2>(this SLProtocol protocol, uint[] paramIds, out T1 param1, out T2 param2)
+            where T1 : IConvertible
+            where T2 : IConvertible
+        {
+            if (paramIds is null)
+            {
+                throw new ArgumentNullException(nameof(paramIds));
+            }
+
+            if (paramIds.Length != 2)
+            {
+                throw new ArgumentOutOfRangeException(nameof(paramIds), "paramIds need to have the same length as the number of out parameters");
+            }
+
+            object[] parameters = (object[])protocol.GetParameters(paramIds);
+
+            param1 = parameters[0].ChangeType<T1>();
+            param2 = parameters[1].ChangeType<T2>();
+        }
+
+        /// <summary>
+		/// Gets the desired parameters and converts to the given types.
+		/// </summary>
+		/// <typeparam name="T1">Type of the fist parameter.</typeparam>
+		/// <typeparam name="T2">Type of the second parameter.</typeparam>
+		/// <typeparam name="T3">Type of the third parameter.</typeparam>
+        /// <param name="protocol">Link with SLProtocol process.</param>
+		/// <param name="paramIds">Array with the ids of the Parameters to fetch.</param>
+		/// <param name="param1">Out variable with the first parameter value.</param>
+		/// <param name="param2">Out variable with the second parameter value.</param>
+		/// <param name="param3">Out variable with the third parameter value.</param>
+		/// <exception cref="ArgumentNullException"><paramref name="paramIds"/> is <see langword="null"/></exception>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// The length of <paramref name="paramIds"/> differs from the number of out parameters.
+		/// </exception>
+        public static void GetParameters<T1, T2, T3>(this SLProtocol protocol, uint[] paramIds, out T1 param1, out T2 param2, out T3 param3)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+        {
+            if (paramIds is null)
+            {
+                throw new ArgumentNullException(nameof(paramIds));
+            }
+
+            if (paramIds.Length != 3)
+            {
+                throw new ArgumentOutOfRangeException(nameof(paramIds), "paramIds need to have the same length as the number of out parameters");
+            }
+
+            object[] parameters = (object[])protocol.GetParameters(paramIds);
+
+            param1 = parameters[0].ChangeType<T1>();
+            param2 = parameters[1].ChangeType<T2>();
+            param3 = parameters[2].ChangeType<T3>();
+        }
+
+        /// <summary>
+		/// Gets the desired parameters and converts to the given types.
+		/// </summary>
+		/// <typeparam name="T1">Type of the fist parameter.</typeparam>
+		/// <typeparam name="T2">Type of the second parameter.</typeparam>
+		/// <typeparam name="T3">Type of the third parameter.</typeparam>
+		/// <typeparam name="T4">Type of the fourth parameter.</typeparam>
+        /// <param name="protocol">Link with SLProtocol process.</param>
+		/// <param name="paramIds">Array with the ids of the Parameters to fetch.</param>
+		/// <param name="param1">Out variable with the first parameter value.</param>
+		/// <param name="param2">Out variable with the second parameter value.</param>
+		/// <param name="param3">Out variable with the third parameter value.</param>
+		/// <param name="param4">Out variable with the fourth parameter value.</param>
+		/// <exception cref="ArgumentNullException"><paramref name="paramIds"/> is <see langword="null"/></exception>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// The length of <paramref name="paramIds"/> differs from the number of out parameters.
+		/// </exception>
+        public static void GetParameters<T1, T2, T3, T4>(this SLProtocol protocol, uint[] paramIds, out T1 param1, out T2 param2, out T3 param3, out T4 param4)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+        {
+            if (paramIds is null)
+            {
+                throw new ArgumentNullException(nameof(paramIds));
+            }
+
+            if (paramIds.Length != 4)
+            {
+                throw new ArgumentOutOfRangeException(nameof(paramIds), "paramIds need to have the same length as the number of out parameters");
+            }
+
+            object[] parameters = (object[])protocol.GetParameters(paramIds);
+
+            param1 = parameters[0].ChangeType<T1>();
+            param2 = parameters[1].ChangeType<T2>();
+            param3 = parameters[2].ChangeType<T3>();
+            param4 = parameters[3].ChangeType<T4>();
+        }
+
+        /// <summary>
+		/// Gets the desired parameters and converts to the given types.
+		/// </summary>
+		/// <typeparam name="T1">Type of the fist parameter.</typeparam>
+		/// <typeparam name="T2">Type of the second parameter.</typeparam>
+		/// <typeparam name="T3">Type of the third parameter.</typeparam>
+		/// <typeparam name="T4">Type of the fourth parameter.</typeparam>
+		/// <typeparam name="T5">Type of the fifth parameter.</typeparam>
+        /// <param name="protocol">Link with SLProtocol process.</param>
+		/// <param name="paramIds">Array with the ids of the Parameters to fetch.</param>
+		/// <param name="param1">Out variable with the first parameter value.</param>
+		/// <param name="param2">Out variable with the second parameter value.</param>
+		/// <param name="param3">Out variable with the third parameter value.</param>
+		/// <param name="param4">Out variable with the fourth parameter value.</param>
+		/// <param name="param5">Out variable with the fifth parameter value.</param>
+		/// <exception cref="ArgumentNullException"><paramref name="paramIds"/> is <see langword="null"/></exception>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// The length of <paramref name="paramIds"/> differs from the number of out parameters.
+		/// </exception>
+        public static void GetParameters<T1, T2, T3, T4, T5>(this SLProtocol protocol, uint[] paramIds, out T1 param1, out T2 param2, out T3 param3, out T4 param4, out T5 param5)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+        {
+            if (paramIds is null)
+            {
+                throw new ArgumentNullException(nameof(paramIds));
+            }
+
+            if (paramIds.Length != 5)
+            {
+                throw new ArgumentOutOfRangeException(nameof(paramIds), "paramIds need to have the same length as the number of out parameters");
+            }
+
+            object[] parameters = (object[])protocol.GetParameters(paramIds);
+
+            param1 = parameters[0].ChangeType<T1>();
+            param2 = parameters[1].ChangeType<T2>();
+            param3 = parameters[2].ChangeType<T3>();
+            param4 = parameters[3].ChangeType<T4>();
+            param5 = parameters[4].ChangeType<T5>();
+        }
+
+        /// <summary>
+		/// Gets the desired parameters and converts to the given types.
+		/// </summary>
+		/// <typeparam name="T1">Type of the fist parameter.</typeparam>
+		/// <typeparam name="T2">Type of the second parameter.</typeparam>
+		/// <typeparam name="T3">Type of the third parameter.</typeparam>
+		/// <typeparam name="T4">Type of the fourth parameter.</typeparam>
+		/// <typeparam name="T5">Type of the fifth parameter.</typeparam>
+		/// <typeparam name="T6">Type of the sixth parameter.</typeparam>
+        /// <param name="protocol">Link with SLProtocol process.</param>
+		/// <param name="paramIds">Array with the ids of the Parameters to fetch.</param>
+		/// <param name="param1">Out variable with the first parameter value.</param>
+		/// <param name="param2">Out variable with the second parameter value.</param>
+		/// <param name="param3">Out variable with the third parameter value.</param>
+		/// <param name="param4">Out variable with the fourth parameter value.</param>
+		/// <param name="param5">Out variable with the fifth parameter value.</param>
+		/// <param name="param6">Out variable with the sixth parameter value.</param>
+		/// <exception cref="ArgumentNullException"><paramref name="paramIds"/> is <see langword="null"/></exception>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// The length of <paramref name="paramIds"/> differs from the number of out parameters.
+		/// </exception>
+        public static void GetParameters<T1, T2, T3, T4, T5, T6>(this SLProtocol protocol, uint[] paramIds, out T1 param1, out T2 param2, out T3 param3, out T4 param4, out T5 param5, out T6 param6)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+            where T6 : IConvertible
+        {
+            if (paramIds is null)
+            {
+                throw new ArgumentNullException(nameof(paramIds));
+            }
+
+            if (paramIds.Length != 6)
+            {
+                throw new ArgumentOutOfRangeException(nameof(paramIds), "paramIds need to have the same length as the number of out parameters");
+            }
+
+            object[] parameters = (object[])protocol.GetParameters(paramIds);
+
+            param1 = parameters[0].ChangeType<T1>();
+            param2 = parameters[1].ChangeType<T2>();
+            param3 = parameters[2].ChangeType<T3>();
+            param4 = parameters[3].ChangeType<T4>();
+            param5 = parameters[4].ChangeType<T5>();
+            param6 = parameters[5].ChangeType<T6>();
+        }
+
+        /// <summary>
+		/// Gets the desired parameters and converts to the given types.
+		/// </summary>
+		/// <typeparam name="T1">Type of the fist parameter.</typeparam>
+		/// <typeparam name="T2">Type of the second parameter.</typeparam>
+		/// <typeparam name="T3">Type of the third parameter.</typeparam>
+		/// <typeparam name="T4">Type of the fourth parameter.</typeparam>
+		/// <typeparam name="T5">Type of the fifth parameter.</typeparam>
+		/// <typeparam name="T6">Type of the sixth parameter.</typeparam>
+		/// <typeparam name="T7">Type of the seventh parameter.</typeparam>
+        /// <param name="protocol">Link with SLProtocol process.</param>
+		/// <param name="paramIds">Array with the ids of the Parameters to fetch.</param>
+		/// <param name="param1">Out variable with the first parameter value.</param>
+		/// <param name="param2">Out variable with the second parameter value.</param>
+		/// <param name="param3">Out variable with the third parameter value.</param>
+		/// <param name="param4">Out variable with the fourth parameter value.</param>
+		/// <param name="param5">Out variable with the fifth parameter value.</param>
+		/// <param name="param6">Out variable with the sixth parameter value.</param>
+		/// <param name="param7">Out variable with the seventh parameter value.</param>
+		/// <exception cref="ArgumentNullException"><paramref name="paramIds"/> is <see langword="null"/></exception>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// The length of <paramref name="paramIds"/> differs from the number of out parameters.
+		/// </exception>
+        public static void GetParameters<T1, T2, T3, T4, T5, T6, T7>(
+            this SLProtocol protocol,
+            uint[] paramIds,
+            out T1 param1,
+            out T2 param2,
+            out T3 param3,
+            out T4 param4,
+            out T5 param5,
+            out T6 param6,
+            out T7 param7)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+            where T6 : IConvertible
+            where T7 : IConvertible
+        {
+            if (paramIds is null)
+            {
+                throw new ArgumentNullException(nameof(paramIds));
+            }
+
+            if (paramIds.Length != 7)
+            {
+                throw new ArgumentOutOfRangeException(nameof(paramIds), "paramIds need to have the same length as the number of out parameters");
+            }
+
+            object[] parameters = (object[])protocol.GetParameters(paramIds);
+
+            param1 = parameters[0].ChangeType<T1>();
+            param2 = parameters[1].ChangeType<T2>();
+            param3 = parameters[2].ChangeType<T3>();
+            param4 = parameters[3].ChangeType<T4>();
+            param5 = parameters[4].ChangeType<T5>();
+            param6 = parameters[5].ChangeType<T6>();
+            param7 = parameters[6].ChangeType<T7>();
+        }
+
+        /// <summary>
+		/// Gets the desired parameters and converts to the given types.
+		/// </summary>
+		/// <typeparam name="T1">Type of the fist parameter.</typeparam>
+		/// <typeparam name="T2">Type of the second parameter.</typeparam>
+		/// <typeparam name="T3">Type of the third parameter.</typeparam>
+		/// <typeparam name="T4">Type of the fourth parameter.</typeparam>
+		/// <typeparam name="T5">Type of the fifth parameter.</typeparam>
+		/// <typeparam name="T6">Type of the sixth parameter.</typeparam>
+		/// <typeparam name="T7">Type of the seventh parameter.</typeparam>
+		/// <typeparam name="T8">Type of the eighth parameter.</typeparam>
+        /// <param name="protocol">Link with SLProtocol process.</param>
+		/// <param name="paramIds">Array with the ids of the Parameters to fetch.</param>
+		/// <param name="param1">Out variable with the first parameter value.</param>
+		/// <param name="param2">Out variable with the second parameter value.</param>
+		/// <param name="param3">Out variable with the third parameter value.</param>
+		/// <param name="param4">Out variable with the fourth parameter value.</param>
+		/// <param name="param5">Out variable with the fifth parameter value.</param>
+		/// <param name="param6">Out variable with the sixth parameter value.</param>
+		/// <param name="param7">Out variable with the seventh parameter value.</param>
+		/// <param name="param8">Out variable with the eighth parameter value.</param>
+		/// <exception cref="ArgumentNullException"><paramref name="paramIds"/> is <see langword="null"/></exception>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// The length of <paramref name="paramIds"/> differs from the number of out parameters.
+		/// </exception>
+        public static void GetParameters<T1, T2, T3, T4, T5, T6, T7, T8>(
+            this SLProtocol protocol,
+            uint[] paramIds,
+            out T1 param1,
+            out T2 param2,
+            out T3 param3,
+            out T4 param4,
+            out T5 param5,
+            out T6 param6,
+            out T7 param7,
+            out T8 param8)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+            where T6 : IConvertible
+            where T7 : IConvertible
+            where T8 : IConvertible
+        {
+            if (paramIds is null)
+            {
+                throw new ArgumentNullException(nameof(paramIds));
+            }
+
+            if (paramIds.Length != 8)
+            {
+                throw new ArgumentOutOfRangeException(nameof(paramIds), "paramIds need to have the same length as the number of out parameters");
+            }
+
+            object[] parameters = (object[])protocol.GetParameters(paramIds);
+
+            param1 = parameters[0].ChangeType<T1>();
+            param2 = parameters[1].ChangeType<T2>();
+            param3 = parameters[2].ChangeType<T3>();
+            param4 = parameters[3].ChangeType<T4>();
+            param5 = parameters[4].ChangeType<T5>();
+            param6 = parameters[5].ChangeType<T6>();
+            param7 = parameters[6].ChangeType<T7>();
+            param8 = parameters[7].ChangeType<T8>();
+        }
+
+        /// <summary>
+		/// Gets the desired parameters and converts to the given types.
+		/// </summary>
+		/// <typeparam name="T1">Type of the fist parameter.</typeparam>
+		/// <typeparam name="T2">Type of the second parameter.</typeparam>
+		/// <typeparam name="T3">Type of the third parameter.</typeparam>
+		/// <typeparam name="T4">Type of the fourth parameter.</typeparam>
+		/// <typeparam name="T5">Type of the fifth parameter.</typeparam>
+		/// <typeparam name="T6">Type of the sixth parameter.</typeparam>
+		/// <typeparam name="T7">Type of the seventh parameter.</typeparam>
+		/// <typeparam name="T8">Type of the eighth parameter.</typeparam>
+		/// <typeparam name="T9">Type of the ninth parameter.</typeparam>
+        /// <param name="protocol">Link with SLProtocol process.</param>
+		/// <param name="paramIds">Array with the ids of the Parameters to fetch.</param>
+		/// <param name="param1">Out variable with the first parameter value.</param>
+		/// <param name="param2">Out variable with the second parameter value.</param>
+		/// <param name="param3">Out variable with the third parameter value.</param>
+		/// <param name="param4">Out variable with the fourth parameter value.</param>
+		/// <param name="param5">Out variable with the fifth parameter value.</param>
+		/// <param name="param6">Out variable with the sixth parameter value.</param>
+		/// <param name="param7">Out variable with the seventh parameter value.</param>
+		/// <param name="param8">Out variable with the eighth parameter value.</param>
+		/// <param name="param9">Out variable with the ninth parameter value.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="paramIds"/> is <see langword="null"/></exception>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// The length of <paramref name="paramIds"/> differs from the number of out parameters.
+		/// </exception>
+        public static void GetParameters<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+            this SLProtocol protocol,
+            uint[] paramIds,
+            out T1 param1,
+            out T2 param2,
+            out T3 param3,
+            out T4 param4,
+            out T5 param5,
+            out T6 param6,
+            out T7 param7,
+            out T8 param8,
+            out T9 param9)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+            where T6 : IConvertible
+            where T7 : IConvertible
+            where T8 : IConvertible
+            where T9 : IConvertible
+        {
+            if (paramIds is null)
+            {
+                throw new ArgumentNullException(nameof(paramIds));
+            }
+
+            if (paramIds.Length != 9)
+            {
+                throw new ArgumentOutOfRangeException(nameof(paramIds), "paramIds need to have the same length as the number of out parameters");
+            }
+
+            object[] parameters = (object[])protocol.GetParameters(paramIds);
+
+            param1 = parameters[0].ChangeType<T1>();
+            param2 = parameters[1].ChangeType<T2>();
+            param3 = parameters[2].ChangeType<T3>();
+            param4 = parameters[3].ChangeType<T4>();
+            param5 = parameters[4].ChangeType<T5>();
+            param6 = parameters[5].ChangeType<T6>();
+            param7 = parameters[6].ChangeType<T7>();
+            param8 = parameters[7].ChangeType<T8>();
+            param9 = parameters[8].ChangeType<T9>();
+        }
+
+        /// <summary>
+		/// Gets the desired parameters and converts to the given types.
+		/// </summary>
+		/// <typeparam name="T1">Type of the fist parameter.</typeparam>
+		/// <typeparam name="T2">Type of the second parameter.</typeparam>
+		/// <typeparam name="T3">Type of the third parameter.</typeparam>
+		/// <typeparam name="T4">Type of the fourth parameter.</typeparam>
+		/// <typeparam name="T5">Type of the fifth parameter.</typeparam>
+		/// <typeparam name="T6">Type of the sixth parameter.</typeparam>
+		/// <typeparam name="T7">Type of the seventh parameter.</typeparam>
+		/// <typeparam name="T8">Type of the eighth parameter.</typeparam>
+		/// <typeparam name="T9">Type of the ninth parameter.</typeparam>
+		/// <typeparam name="T10">Type of the tenth parameter.</typeparam>
+		/// <param name="paramIds">Array with the ids of the Parameters to fetch.</param>
+		/// <param name="param1">Out variable with the first parameter value.</param>
+		/// <param name="param2">Out variable with the second parameter value.</param>
+		/// <param name="param3">Out variable with the third parameter value.</param>
+		/// <param name="param4">Out variable with the fourth parameter value.</param>
+		/// <param name="param5">Out variable with the fifth parameter value.</param>
+		/// <param name="param6">Out variable with the sixth parameter value.</param>
+		/// <param name="param7">Out variable with the seventh parameter value.</param>
+		/// <param name="param8">Out variable with the eighth parameter value.</param>
+		/// <param name="param9">Out variable with the ninth parameter value.</param>
+		/// <param name="param10">Out variable with the tenth parameter value.</param>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// If the length of the paramIds is different from the number of out parameters.
+		/// </exception>
+        public static void GetParameters<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+            this SLProtocol protocol,
+            uint[] paramIds,
+            out T1 param1,
+            out T2 param2,
+            out T3 param3,
+            out T4 param4,
+            out T5 param5,
+            out T6 param6,
+            out T7 param7,
+            out T8 param8,
+            out T9 param9,
+            out T10 param10)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+            where T6 : IConvertible
+            where T7 : IConvertible
+            where T8 : IConvertible
+            where T9 : IConvertible
+            where T10 : IConvertible
+        {
+            if (paramIds is null)
+            {
+                throw new ArgumentNullException(nameof(paramIds));
+            }
+
+            if (paramIds.Length != 10)
+            {
+                throw new ArgumentOutOfRangeException(nameof(paramIds), "paramIds need to have the same length as the number of out parameters");
+            }
+
+            object[] parameters = (object[])protocol.GetParameters(paramIds);
+
+            param1 = parameters[0].ChangeType<T1>();
+            param2 = parameters[1].ChangeType<T2>();
+            param3 = parameters[2].ChangeType<T3>();
+            param4 = parameters[3].ChangeType<T4>();
+            param5 = parameters[4].ChangeType<T5>();
+            param6 = parameters[5].ChangeType<T6>();
+            param7 = parameters[6].ChangeType<T7>();
+            param8 = parameters[7].ChangeType<T8>();
+            param9 = parameters[8].ChangeType<T9>();
+            param10 = parameters[9].ChangeType<T10>();
+        }
+
+        /// <summary>
         /// Runs the specified action.
         /// </summary>
         /// <param name="protocol">Link with SLProtocol process.</param>

--- a/Utils.Protocol.Extension/ProtocolExtension.cs
+++ b/Utils.Protocol.Extension/ProtocolExtension.cs
@@ -936,9 +936,9 @@
 
             ValidateResult(result, paramIds, out object[] parameters);
 
-			param1 = parameters[0].ChangeType<T1>();
-			param2 = parameters[1].ChangeType<T2>();
-		}
+            param1 = parameters[0].ChangeType<T1>();
+            param2 = parameters[1].ChangeType<T2>();
+        }
 
         /// <summary>
         /// Gets the desired parameters and converts to the given types.
@@ -968,9 +968,9 @@
             ValidateResult(result, paramIds, out object[] parameters);
 
             param1 = parameters[0].ChangeType<T1>();
-			param2 = parameters[1].ChangeType<T2>();
-			param3 = parameters[2].ChangeType<T3>();
-		}
+            param2 = parameters[1].ChangeType<T2>();
+            param3 = parameters[2].ChangeType<T3>();
+        }
 
         /// <summary>
         /// Gets the desired parameters and converts to the given types.
@@ -1003,10 +1003,10 @@
             ValidateResult(result, paramIds, out object[] parameters);
 
             param1 = parameters[0].ChangeType<T1>();
-			param2 = parameters[1].ChangeType<T2>();
-			param3 = parameters[2].ChangeType<T3>();
-			param4 = parameters[3].ChangeType<T4>();
-		}
+            param2 = parameters[1].ChangeType<T2>();
+            param3 = parameters[2].ChangeType<T3>();
+            param4 = parameters[3].ChangeType<T4>();
+        }
 
         /// <summary>
         /// Gets the desired parameters and converts to the given types.
@@ -1041,12 +1041,12 @@
 
             ValidateResult(result, paramIds, out object[] parameters);
 
-			param1 = parameters[0].ChangeType<T1>();
-			param2 = parameters[1].ChangeType<T2>();
-			param3 = parameters[2].ChangeType<T3>();
-			param4 = parameters[3].ChangeType<T4>();
-			param5 = parameters[4].ChangeType<T5>();
-		}
+            param1 = parameters[0].ChangeType<T1>();
+            param2 = parameters[1].ChangeType<T2>();
+            param3 = parameters[2].ChangeType<T3>();
+            param4 = parameters[3].ChangeType<T4>();
+            param5 = parameters[4].ChangeType<T5>();
+        }
 
         /// <summary>
         /// Gets the desired parameters and converts to the given types.
@@ -1084,13 +1084,13 @@
 
             ValidateResult(result, paramIds, out object[] parameters);
 
-			param1 = parameters[0].ChangeType<T1>();
-			param2 = parameters[1].ChangeType<T2>();
-			param3 = parameters[2].ChangeType<T3>();
-			param4 = parameters[3].ChangeType<T4>();
-			param5 = parameters[4].ChangeType<T5>();
-			param6 = parameters[5].ChangeType<T6>();
-		}
+            param1 = parameters[0].ChangeType<T1>();
+            param2 = parameters[1].ChangeType<T2>();
+            param3 = parameters[2].ChangeType<T3>();
+            param4 = parameters[3].ChangeType<T4>();
+            param5 = parameters[4].ChangeType<T5>();
+            param6 = parameters[5].ChangeType<T6>();
+        }
 
         /// <summary>
         /// Gets the desired parameters and converts to the given types.
@@ -1140,14 +1140,14 @@
 
             ValidateResult(result, paramIds, out object[] parameters);
 
-			param1 = parameters[0].ChangeType<T1>();
-			param2 = parameters[1].ChangeType<T2>();
-			param3 = parameters[2].ChangeType<T3>();
-			param4 = parameters[3].ChangeType<T4>();
-			param5 = parameters[4].ChangeType<T5>();
-			param6 = parameters[5].ChangeType<T6>();
-			param7 = parameters[6].ChangeType<T7>();
-		}
+            param1 = parameters[0].ChangeType<T1>();
+            param2 = parameters[1].ChangeType<T2>();
+            param3 = parameters[2].ChangeType<T3>();
+            param4 = parameters[3].ChangeType<T4>();
+            param5 = parameters[4].ChangeType<T5>();
+            param6 = parameters[5].ChangeType<T6>();
+            param7 = parameters[6].ChangeType<T7>();
+        }
 
         /// <summary>
         /// Gets the desired parameters and converts to the given types.
@@ -1201,15 +1201,15 @@
 
             ValidateResult(result, paramIds, out object[] parameters);
 
-			param1 = parameters[0].ChangeType<T1>();
-			param2 = parameters[1].ChangeType<T2>();
-			param3 = parameters[2].ChangeType<T3>();
-			param4 = parameters[3].ChangeType<T4>();
-			param5 = parameters[4].ChangeType<T5>();
-			param6 = parameters[5].ChangeType<T6>();
-			param7 = parameters[6].ChangeType<T7>();
-			param8 = parameters[7].ChangeType<T8>();
-		}
+            param1 = parameters[0].ChangeType<T1>();
+            param2 = parameters[1].ChangeType<T2>();
+            param3 = parameters[2].ChangeType<T3>();
+            param4 = parameters[3].ChangeType<T4>();
+            param5 = parameters[4].ChangeType<T5>();
+            param6 = parameters[5].ChangeType<T6>();
+            param7 = parameters[6].ChangeType<T7>();
+            param8 = parameters[7].ChangeType<T8>();
+        }
 
         /// <summary>
         /// Gets the desired parameters and converts to the given types.
@@ -1267,16 +1267,16 @@
 
             ValidateResult(result, paramIds, out object[] parameters);
 
-			param1 = parameters[0].ChangeType<T1>();
-			param2 = parameters[1].ChangeType<T2>();
-			param3 = parameters[2].ChangeType<T3>();
-			param4 = parameters[3].ChangeType<T4>();
-			param5 = parameters[4].ChangeType<T5>();
-			param6 = parameters[5].ChangeType<T6>();
-			param7 = parameters[6].ChangeType<T7>();
-			param8 = parameters[7].ChangeType<T8>();
-			param9 = parameters[8].ChangeType<T9>();
-		}
+            param1 = parameters[0].ChangeType<T1>();
+            param2 = parameters[1].ChangeType<T2>();
+            param3 = parameters[2].ChangeType<T3>();
+            param4 = parameters[3].ChangeType<T4>();
+            param5 = parameters[4].ChangeType<T5>();
+            param6 = parameters[5].ChangeType<T6>();
+            param7 = parameters[6].ChangeType<T7>();
+            param8 = parameters[7].ChangeType<T8>();
+            param9 = parameters[8].ChangeType<T9>();
+        }
 
         /// <summary>
         /// Gets the desired parameters and converts to the given types.
@@ -1784,7 +1784,7 @@
                 throw new InvalidOperationException($"Unexpected result format when retrieving parameters {String.Join(",", paramIds)}. Expected {paramIds.Length} parameters but only received {parameters.Length} values.");
             }
 
-            for(int i = 0; i < paramIds.Length; i++)
+            for (int i = 0; i < paramIds.Length; i++)
             {
                 if (parameters[i] == null)
                 {

--- a/Utils.Protocol.Extension/ProtocolExtension.cs
+++ b/Utils.Protocol.Extension/ProtocolExtension.cs
@@ -106,6 +106,24 @@
         }
 
         /// <summary>
+        /// Gets a column with the desired format.
+        /// </summary>
+        /// <typeparam name="T">Type of the Column.</typeparam>
+        /// <param name="protocol">Link with SLProtocol process.</param>
+        /// <param name="tableId">Id of the table to fetch the column from.</param>
+        /// <param name="columnIdx">Index of the desired column.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> with the desired column.</returns>
+        /// <exception cref="InvalidOperationException">Thrown if the returned data is null, not in the expected format, or contains inconsistent row counts across columns.</exception>
+        public static IEnumerable<T> GetColumn<T>(this SLProtocol protocol, int tableId, uint columnIdx)
+            where T : IConvertible
+        {
+            object result = protocol.NotifyProtocol(321, tableId, new[] { columnIdx });
+
+            ValidateResult(tableId, new uint[] { columnIdx }, 1, result, out object[] columns, out int rowCount);
+            return GetColumnIterator<T>((object[])columns[0], rowCount);
+        }
+
+        /// <summary>
         /// Retrieves the values of the columns with the specified <paramref name="tablePid"/> and <paramref name="columnsIdx"/>.
         /// </summary>
         /// <param name="protocol">Link with SLProtocol process.</param>
@@ -190,84 +208,53 @@
         }
 
         /// <summary>
-		/// Gets a column with the desired format.
-		/// </summary>
-		/// <typeparam name="T">Type of the Column.</typeparam>
-        /// <param name="protocol">Link with SLProtocol process.</param>
-		/// <param name="tableId">Id of the table to fetch the column from.</param>
-		/// <param name="columnIdx">Index of the desired column.</param>
-		/// <returns>An <see cref="IEnumerable{T}"/> with the desired column.</returns>
-        public static IEnumerable<T> GetColumn<T>(this SLProtocol protocol, int tableId, uint columnIdx)
-            where T : IConvertible
-        {
-            var column = (object[])((object[])protocol.NotifyProtocol(321, tableId, new[] { columnIdx }))[0];
-
-            for (var i = 0; i < column.Length; i++)
-            {
-                yield return column[i].ChangeType<T>();
-            }
-        }
-
-        /// <summary>
-		/// Gets two columns from a table and returns an array with the given selector.
-		/// </summary>
-		/// <typeparam name="T1">Type of the first Column.</typeparam>
-		/// <typeparam name="T2">Type of the second Column.</typeparam>
-		/// <typeparam name="TReturn">Type of the return value.</typeparam>
+        /// Gets two columns from a table and returns an array with the given selector.
+        /// </summary>
+        /// <typeparam name="T1">Type of the first Column.</typeparam>
+        /// <typeparam name="T2">Type of the second Column.</typeparam>
+        /// <typeparam name="TReturn">Type of the return value.</typeparam>
         /// <param name="protocol">Link with SLProtocol process.</param>
         /// <param name="tableId">Id of the table to fetch the columns from.</param>
-		/// <param name="columnIndices">Array with the Columns Indexes.</param>
-		/// <param name="returnSelector">A function to map each column element to a return element.</param>
-		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
-		/// <exception cref="ArgumentOutOfRangeException">
-		/// Number of columns doesn't match the number of returned members.
-		/// </exception>
+        /// <param name="columnIndices">Array with the Columns Indexes.</param>
+        /// <param name="returnSelector">A function to map each column element to a return element.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="columnIndices"/> or <paramref name="returnSelector"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Number of columns doesn't match the number of returned members.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Thrown if the returned data is null, not in the expected format, or contains inconsistent row counts across columns.</exception>
         public static IEnumerable<TReturn> GetColumns<T1, T2, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices, Func<T1, T2, TReturn> returnSelector)
             where T1 : IConvertible
             where T2 : IConvertible
         {
             const int columnCount = 2;
 
-            if (columnIndices == null)
-            {
-                throw new ArgumentNullException(nameof(columnIndices));
-            }
+            ValidateGetColumnsArguments(columnIndices, columnCount, returnSelector);
 
-            if (returnSelector == null)
-            {
-                throw new ArgumentNullException(nameof(returnSelector));
-            }
+            object result = protocol.NotifyProtocol(321, tableId, columnIndices);
 
-            if (columnIndices.Length != columnCount)
-            {
-                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
-            }
+            ValidateResult(tableId, columnIndices, columnCount, result, out object[] columns, out int rowCount);
 
-            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
-
-            for (var i = 0; i < ((object[])columns[0]).Length; i++)
-            {
-                yield return returnSelector(
-                    ((object[])columns[0])[i].ChangeType<T1>(),
-                    ((object[])columns[1])[i].ChangeType<T2>());
-            }
+            return GetColumnsIterator(columns, rowCount, returnSelector);
         }
 
         /// <summary>
-		/// Gets three columns from a table and returns an array with the given selector.
-		/// </summary>
-		/// <typeparam name="T1">Type of the first Column.</typeparam>
-		/// <typeparam name="T2">Type of the second Column.</typeparam>
-		/// <typeparam name="T3">Type of the third Column.</typeparam>
-		/// <typeparam name="TReturn">Type of the return value.</typeparam>
+        /// Gets three columns from a table and returns an array with the given selector.
+        /// </summary>
+        /// <typeparam name="T1">Type of the first Column.</typeparam>
+        /// <typeparam name="T2">Type of the second Column.</typeparam>
+        /// <typeparam name="T3">Type of the third Column.</typeparam>
+        /// <typeparam name="TReturn">Type of the return value.</typeparam>
         /// <param name="protocol">Link with SLProtocol process.</param>
         /// <param name="tableId">Id of the table to fetch the columns from.</param>
-		/// <param name="columnIndices">Array with the Columns Indexes.</param>
-		/// <param name="returnSelector">A function to map each column element to a return element.</param>
-		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
-		/// <exception cref="ArgumentOutOfRangeException">
-		/// Number of columns doesn't match the number of returned members.
-		/// </exception>
+        /// <param name="columnIndices">Array with the Columns Indexes.</param>
+        /// <param name="returnSelector">A function to map each column element to a return element.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="columnIndices"/> or <paramref name="returnSelector"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Number of columns doesn't match the number of returned members.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Thrown if the returned data is null, not in the expected format, or contains inconsistent row counts across columns.</exception>
         public static IEnumerable<TReturn> GetColumns<T1, T2, T3, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices, Func<T1, T2, T3, TReturn> returnSelector)
             where T1 : IConvertible
             where T2 : IConvertible
@@ -275,30 +262,13 @@
         {
             const int columnCount = 3;
 
-            if (columnIndices == null)
-            {
-                throw new ArgumentNullException(nameof(columnIndices));
-            }
+            ValidateGetColumnsArguments(columnIndices, columnCount, returnSelector);
 
-            if (returnSelector == null)
-            {
-                throw new ArgumentNullException(nameof(returnSelector));
-            }
+            object result = protocol.NotifyProtocol(321, tableId, columnIndices);
 
-            if (columnIndices.Length != columnCount)
-            {
-                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
-            }
+            ValidateResult(tableId, columnIndices, columnCount, result, out object[] columns, out int rowCount);
 
-            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
-
-            for (var i = 0; i < ((object[])columns[0]).Length; i++)
-            {
-                yield return returnSelector(
-                    ((object[])columns[0])[i].ChangeType<T1>(),
-                    ((object[])columns[1])[i].ChangeType<T2>(),
-                    ((object[])columns[2])[i].ChangeType<T3>());
-            }
+            return GetColumnsIterator(columns, rowCount, returnSelector);
         }
 
         /// <summary>
@@ -314,9 +284,11 @@
 		/// <param name="columnIndices">Array with the Columns Indexes.</param>
 		/// <param name="returnSelector">A function to map each column element to a return element.</param>
 		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
-		/// <exception cref="ArgumentOutOfRangeException">
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="columnIndices"/> or <paramref name="returnSelector"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
 		/// Number of columns doesn't match the number of returned members.
 		/// </exception>
+        /// <exception cref="InvalidOperationException">Thrown if the returned data is null, not in the expected format, or contains inconsistent row counts across columns.</exception>
         public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices, Func<T1, T2, T3, T4, TReturn> returnSelector)
             where T1 : IConvertible
             where T2 : IConvertible
@@ -325,31 +297,13 @@
         {
             const int columnCount = 4;
 
-            if (columnIndices == null)
-            {
-                throw new ArgumentNullException(nameof(columnIndices));
-            }
+            ValidateGetColumnsArguments(columnIndices, columnCount, returnSelector);
 
-            if (returnSelector == null)
-            {
-                throw new ArgumentNullException(nameof(returnSelector));
-            }
+            object result = protocol.NotifyProtocol(321, tableId, columnIndices);
 
-            if (columnIndices.Length != columnCount)
-            {
-                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
-            }
+            ValidateResult(tableId, columnIndices, columnCount, result, out object[] columns, out int rowCount);
 
-            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
-
-            for (var i = 0; i < ((object[])columns[0]).Length; i++)
-            {
-                yield return returnSelector(
-                    ((object[])columns[0])[i].ChangeType<T1>(),
-                    ((object[])columns[1])[i].ChangeType<T2>(),
-                    ((object[])columns[2])[i].ChangeType<T3>(),
-                    ((object[])columns[3])[i].ChangeType<T4>());
-            }
+            return GetColumnsIterator(columns, rowCount, returnSelector);
         }
 
         /// <summary>
@@ -366,9 +320,11 @@
 		/// <param name="columnIndices">Array with the Columns Indexes.</param>
 		/// <param name="returnSelector">A function to map each column element to a return element.</param>
 		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
-		/// <exception cref="ArgumentOutOfRangeException">
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="columnIndices"/> or <paramref name="returnSelector"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
 		/// Number of columns doesn't match the number of returned members.
 		/// </exception>
+        /// <exception cref="InvalidOperationException">Thrown if the returned data is null, not in the expected format, or contains inconsistent row counts across columns.</exception>
         public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices, Func<T1, T2, T3, T4, T5, TReturn> returnSelector)
             where T1 : IConvertible
             where T2 : IConvertible
@@ -378,32 +334,13 @@
         {
             const int columnCount = 5;
 
-            if (columnIndices == null)
-            {
-                throw new ArgumentNullException(nameof(columnIndices));
-            }
+            ValidateGetColumnsArguments(columnIndices, columnCount, returnSelector);
 
-            if (returnSelector == null)
-            {
-                throw new ArgumentNullException(nameof(returnSelector));
-            }
+            object result = protocol.NotifyProtocol(321, tableId, columnIndices);
 
-            if (columnIndices.Length != columnCount)
-            {
-                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
-            }
+            ValidateResult(tableId, columnIndices, columnCount, result, out object[] columns, out int rowCount);
 
-            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
-
-            for (var i = 0; i < ((object[])columns[0]).Length; i++)
-            {
-                yield return returnSelector(
-                    ((object[])columns[0])[i].ChangeType<T1>(),
-                    ((object[])columns[1])[i].ChangeType<T2>(),
-                    ((object[])columns[2])[i].ChangeType<T3>(),
-                    ((object[])columns[3])[i].ChangeType<T4>(),
-                    ((object[])columns[4])[i].ChangeType<T5>());
-            }
+            return GetColumnsIterator(columns, rowCount, returnSelector);
         }
 
         /// <summary>
@@ -421,9 +358,11 @@
 		/// <param name="columnIndices">Array with the Columns Indexes.</param>
 		/// <param name="returnSelector">A function to map each column element to a return element.</param>
 		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
-		/// <exception cref="ArgumentOutOfRangeException">
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="columnIndices"/> or <paramref name="returnSelector"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
 		/// Number of columns doesn't match the number of returned members.
 		/// </exception>
+        /// <exception cref="InvalidOperationException">Thrown if the returned data is null, not in the expected format, or contains inconsistent row counts across columns.</exception>
         public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
             Func<T1, T2, T3, T4, T5, T6, TReturn> returnSelector)
             where T1 : IConvertible
@@ -435,33 +374,13 @@
         {
             const int columnCount = 6;
 
-            if (columnIndices == null)
-            {
-                throw new ArgumentNullException(nameof(columnIndices));
-            }
+            ValidateGetColumnsArguments(columnIndices, columnCount, returnSelector);
 
-            if (returnSelector == null)
-            {
-                throw new ArgumentNullException(nameof(returnSelector));
-            }
+            object result = protocol.NotifyProtocol(321, tableId, columnIndices);
 
-            if (columnIndices.Length != columnCount)
-            {
-                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
-            }
+            ValidateResult(tableId, columnIndices, columnCount, result, out object[] columns, out int rowCount);
 
-            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
-
-            for (var i = 0; i < ((object[])columns[0]).Length; i++)
-            {
-                yield return returnSelector(
-                    ((object[])columns[0])[i].ChangeType<T1>(),
-                    ((object[])columns[1])[i].ChangeType<T2>(),
-                    ((object[])columns[2])[i].ChangeType<T3>(),
-                    ((object[])columns[3])[i].ChangeType<T4>(),
-                    ((object[])columns[4])[i].ChangeType<T5>(),
-                    ((object[])columns[5])[i].ChangeType<T6>());
-            }
+            return GetColumnsIterator(columns, rowCount, returnSelector);
         }
 
         /// <summary>
@@ -480,9 +399,11 @@
 		/// <param name="columnIndices">Array with the Columns Indexes.</param>
 		/// <param name="returnSelector">A function to map each column element to a return element.</param>
 		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
-		/// <exception cref="ArgumentOutOfRangeException">
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="columnIndices"/> or <paramref name="returnSelector"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
 		/// Number of columns doesn't match the number of returned members.
 		/// </exception>
+        /// <exception cref="InvalidOperationException">Thrown if the returned data is null, not in the expected format, or contains inconsistent row counts across columns.</exception>
         public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, T7, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
             Func<T1, T2, T3, T4, T5, T6, T7, TReturn> returnSelector)
             where T1 : IConvertible
@@ -495,34 +416,13 @@
         {
             const int columnCount = 7;
 
-            if (columnIndices == null)
-            {
-                throw new ArgumentNullException(nameof(columnIndices));
-            }
+            ValidateGetColumnsArguments(columnIndices, columnCount, returnSelector);
 
-            if (returnSelector == null)
-            {
-                throw new ArgumentNullException(nameof(returnSelector));
-            }
+            object result = protocol.NotifyProtocol(321, tableId, columnIndices);
 
-            if (columnIndices.Length != columnCount)
-            {
-                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
-            }
+            ValidateResult(tableId, columnIndices, columnCount, result, out object[] columns, out int rowCount);
 
-            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
-
-            for (var i = 0; i < ((object[])columns[0]).Length; i++)
-            {
-                yield return returnSelector(
-                    ((object[])columns[0])[i].ChangeType<T1>(),
-                    ((object[])columns[1])[i].ChangeType<T2>(),
-                    ((object[])columns[2])[i].ChangeType<T3>(),
-                    ((object[])columns[3])[i].ChangeType<T4>(),
-                    ((object[])columns[4])[i].ChangeType<T5>(),
-                    ((object[])columns[5])[i].ChangeType<T6>(),
-                    ((object[])columns[6])[i].ChangeType<T7>());
-            }
+            return GetColumnsIterator(columns, rowCount, returnSelector);
         }
 
         /// <summary>
@@ -542,9 +442,11 @@
 		/// <param name="columnIndices">Array with the Columns Indexes.</param>
 		/// <param name="returnSelector">A function to map each column element to a return element.</param>
 		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
-		/// <exception cref="ArgumentOutOfRangeException">
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="columnIndices"/> or <paramref name="returnSelector"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
 		/// Number of columns doesn't match the number of returned members.
 		/// </exception>
+        /// <exception cref="InvalidOperationException">Thrown if the returned data is null, not in the expected format, or contains inconsistent row counts across columns.</exception>
         public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, T7, T8, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
             Func<T1, T2, T3, T4, T5, T6, T7, T8, TReturn> returnSelector)
             where T1 : IConvertible
@@ -558,35 +460,13 @@
         {
             const int columnCount = 8;
 
-            if (columnIndices == null)
-            {
-                throw new ArgumentNullException(nameof(columnIndices));
-            }
+            ValidateGetColumnsArguments(columnIndices, columnCount, returnSelector);
 
-            if (returnSelector == null)
-            {
-                throw new ArgumentNullException(nameof(returnSelector));
-            }
+            object result = protocol.NotifyProtocol(321, tableId, columnIndices);
 
-            if (columnIndices.Length != columnCount)
-            {
-                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
-            }
+            ValidateResult(tableId, columnIndices, columnCount, result, out object[] columns, out int rowCount);
 
-            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
-
-            for (var i = 0; i < ((object[])columns[0]).Length; i++)
-            {
-                yield return returnSelector(
-                    ((object[])columns[0])[i].ChangeType<T1>(),
-                    ((object[])columns[1])[i].ChangeType<T2>(),
-                    ((object[])columns[2])[i].ChangeType<T3>(),
-                    ((object[])columns[3])[i].ChangeType<T4>(),
-                    ((object[])columns[4])[i].ChangeType<T5>(),
-                    ((object[])columns[5])[i].ChangeType<T6>(),
-                    ((object[])columns[6])[i].ChangeType<T7>(),
-                    ((object[])columns[7])[i].ChangeType<T8>());
-            }
+            return GetColumnsIterator(columns, rowCount, returnSelector);
         }
 
         /// <summary>
@@ -607,9 +487,11 @@
 		/// <param name="columnIndices">Array with the Columns Indexes.</param>
 		/// <param name="returnSelector">A function to map each column element to a return element.</param>
 		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
-		/// <exception cref="ArgumentOutOfRangeException">
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="columnIndices"/> or <paramref name="returnSelector"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
 		/// Number of columns doesn't match the number of returned members.
 		/// </exception>
+        /// <exception cref="InvalidOperationException">Thrown if the returned data is null, not in the expected format, or contains inconsistent row counts across columns.</exception>
         public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, T7, T8, T9, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TReturn> returnSelector)
             where T1 : IConvertible
@@ -624,60 +506,40 @@
         {
             const int columnCount = 9;
 
-            if (columnIndices == null)
-            {
-                throw new ArgumentNullException(nameof(columnIndices));
-            }
+            ValidateGetColumnsArguments(columnIndices, columnCount, returnSelector);
 
-            if (returnSelector == null)
-            {
-                throw new ArgumentNullException(nameof(returnSelector));
-            }
+            object result = protocol.NotifyProtocol(321, tableId, columnIndices);
 
-            if (columnIndices.Length != columnCount)
-            {
-                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
-            }
+            ValidateResult(tableId, columnIndices, columnCount, result, out object[] columns, out int rowCount);
 
-            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
-
-            for (var i = 0; i < ((object[])columns[0]).Length; i++)
-            {
-                yield return returnSelector(
-                    ((object[])columns[0])[i].ChangeType<T1>(),
-                    ((object[])columns[1])[i].ChangeType<T2>(),
-                    ((object[])columns[2])[i].ChangeType<T3>(),
-                    ((object[])columns[3])[i].ChangeType<T4>(),
-                    ((object[])columns[4])[i].ChangeType<T5>(),
-                    ((object[])columns[5])[i].ChangeType<T6>(),
-                    ((object[])columns[6])[i].ChangeType<T7>(),
-                    ((object[])columns[7])[i].ChangeType<T8>(),
-                    ((object[])columns[8])[i].ChangeType<T9>());
-            }
+            return GetColumnsIterator(columns, rowCount, returnSelector);
         }
 
+
         /// <summary>
-		/// Gets ten columns from a table and returns an array with the given selector.
-		/// </summary>
-		/// <typeparam name="T1">Type of the first Column.</typeparam>
-		/// <typeparam name="T2">Type of the second Column.</typeparam>
-		/// <typeparam name="T3">Type of the third Column.</typeparam>
-		/// <typeparam name="T4">Type of the fourth Column.</typeparam>
-		/// <typeparam name="T5">Type of the fifth Column.</typeparam>
-		/// <typeparam name="T6">Type of the sixth Column.</typeparam>
-		/// <typeparam name="T7">Type of the seventh Column.</typeparam>
-		/// <typeparam name="T8">Type of the eighth Column.</typeparam>
-		/// <typeparam name="T9">Type of the ninth Column.</typeparam>
-		/// <typeparam name="T10">Type of the tenth Column.</typeparam>
-		/// <typeparam name="TReturn">Type of the return value.</typeparam>
-		/// <param name="protocol">Link with SLProtocol process.</param>
-		/// <param name="tableId">Id of the table to fetch the columns from.</param>
-		/// <param name="columnIndices">Array with the Columns Indexes.</param>
-		/// <param name="returnSelector">A function to map each column element to a return element.</param>
-		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
-		/// <exception cref="ArgumentOutOfRangeException">
-		/// Number of columns doesn't match the number of returned members.
-		/// </exception>
+        /// Gets ten columns from a table and returns an array with the given selector.
+        /// </summary>
+        /// <typeparam name="T1">Type of the first Column.</typeparam>
+        /// <typeparam name="T2">Type of the second Column.</typeparam>
+        /// <typeparam name="T3">Type of the third Column.</typeparam>
+        /// <typeparam name="T4">Type of the fourth Column.</typeparam>
+        /// <typeparam name="T5">Type of the fifth Column.</typeparam>
+        /// <typeparam name="T6">Type of the sixth Column.</typeparam>
+        /// <typeparam name="T7">Type of the seventh Column.</typeparam>
+        /// <typeparam name="T8">Type of the eighth Column.</typeparam>
+        /// <typeparam name="T9">Type of the ninth Column.</typeparam>
+        /// <typeparam name="T10">Type of the tenth Column.</typeparam>
+        /// <typeparam name="TReturn">Type of the return value.</typeparam>
+        /// <param name="protocol">Link with SLProtocol process.</param>
+        /// <param name="tableId">Id of the table to fetch the columns from.</param>
+        /// <param name="columnIndices">Array with the Columns Indexes.</param>
+        /// <param name="returnSelector">A function to map each column element to a return element.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="columnIndices"/> or <paramref name="returnSelector"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Number of columns doesn't match the number of returned members.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Thrown if the returned data is null, not in the expected format, or contains inconsistent row counts across columns.</exception>
         public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TReturn> returnSelector)
             where T1 : IConvertible
@@ -693,37 +555,13 @@
         {
             const int columnCount = 10;
 
-            if (columnIndices == null)
-            {
-                throw new ArgumentNullException(nameof(columnIndices));
-            }
+            ValidateGetColumnsArguments(columnIndices, columnCount, returnSelector);
 
-            if (returnSelector == null)
-            {
-                throw new ArgumentNullException(nameof(returnSelector));
-            }
+            object result = protocol.NotifyProtocol(321, tableId, columnIndices);
 
-            if (columnIndices.Length != columnCount)
-            {
-                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
-            }
+            ValidateResult(tableId, columnIndices, columnCount, result, out object[] columns, out int rowCount);
 
-            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
-
-            for (var i = 0; i < ((object[])columns[0]).Length; i++)
-            {
-                yield return returnSelector(
-                    ((object[])columns[0])[i].ChangeType<T1>(),
-                    ((object[])columns[1])[i].ChangeType<T2>(),
-                    ((object[])columns[2])[i].ChangeType<T3>(),
-                    ((object[])columns[3])[i].ChangeType<T4>(),
-                    ((object[])columns[4])[i].ChangeType<T5>(),
-                    ((object[])columns[5])[i].ChangeType<T6>(),
-                    ((object[])columns[6])[i].ChangeType<T7>(),
-                    ((object[])columns[7])[i].ChangeType<T8>(),
-                    ((object[])columns[8])[i].ChangeType<T9>(),
-                    ((object[])columns[9])[i].ChangeType<T10>());
-            }
+            return GetColumnsIterator(columns, rowCount, returnSelector);
         }
 
         /// <summary>
@@ -746,9 +584,11 @@
 		/// <param name="columnIndices">Array with the Columns Indexes.</param>
 		/// <param name="returnSelector">A function to map each column element to a return element.</param>
 		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
-		/// <exception cref="ArgumentOutOfRangeException">
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="columnIndices"/> or <paramref name="returnSelector"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
 		/// Number of columns doesn't match the number of returned members.
 		/// </exception>
+        /// <exception cref="InvalidOperationException">Thrown if the returned data is null, not in the expected format, or contains inconsistent row counts across columns.</exception>
         public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TReturn> returnSelector)
             where T1 : IConvertible
@@ -765,38 +605,13 @@
         {
             const int columnCount = 11;
 
-            if (columnIndices == null)
-            {
-                throw new ArgumentNullException(nameof(columnIndices));
-            }
+            ValidateGetColumnsArguments(columnIndices, columnCount, returnSelector);
 
-            if (returnSelector == null)
-            {
-                throw new ArgumentNullException(nameof(returnSelector));
-            }
+            object result = protocol.NotifyProtocol(321, tableId, columnIndices);
 
-            if (columnIndices.Length != columnCount)
-            {
-                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
-            }
+            ValidateResult(tableId, columnIndices, columnCount, result, out object[] columns, out int rowCount);
 
-            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
-
-            for (var i = 0; i < ((object[])columns[0]).Length; i++)
-            {
-                yield return returnSelector(
-                    ((object[])columns[0])[i].ChangeType<T1>(),
-                    ((object[])columns[1])[i].ChangeType<T2>(),
-                    ((object[])columns[2])[i].ChangeType<T3>(),
-                    ((object[])columns[3])[i].ChangeType<T4>(),
-                    ((object[])columns[4])[i].ChangeType<T5>(),
-                    ((object[])columns[5])[i].ChangeType<T6>(),
-                    ((object[])columns[6])[i].ChangeType<T7>(),
-                    ((object[])columns[7])[i].ChangeType<T8>(),
-                    ((object[])columns[8])[i].ChangeType<T9>(),
-                    ((object[])columns[9])[i].ChangeType<T10>(),
-                    ((object[])columns[10])[i].ChangeType<T11>());
-            }
+            return GetColumnsIterator(columns, rowCount, returnSelector);
         }
 
         /// <summary>
@@ -820,9 +635,11 @@
 		/// <param name="columnIndices">Array with the Columns Indexes.</param>
 		/// <param name="returnSelector">A function to map each column element to a return element.</param>
 		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
-		/// <exception cref="ArgumentOutOfRangeException">
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="columnIndices"/> or <paramref name="returnSelector"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
 		/// Number of columns doesn't match the number of returned members.
 		/// </exception>
+        /// <exception cref="InvalidOperationException">Thrown if the returned data is null, not in the expected format, or contains inconsistent row counts across columns.</exception>
         public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TReturn> returnSelector)
             where T1 : IConvertible
@@ -840,39 +657,13 @@
         {
             const int columnCount = 12;
 
-            if (columnIndices == null)
-            {
-                throw new ArgumentNullException(nameof(columnIndices));
-            }
+            ValidateGetColumnsArguments(columnIndices, columnCount, returnSelector);
 
-            if (returnSelector == null)
-            {
-                throw new ArgumentNullException(nameof(returnSelector));
-            }
+            object result = protocol.NotifyProtocol(321, tableId, columnIndices);
 
-            if (columnIndices.Length != columnCount)
-            {
-                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
-            }
+            ValidateResult(tableId, columnIndices, columnCount, result, out object[] columns, out int rowCount);
 
-            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
-
-            for (var i = 0; i < ((object[])columns[0]).Length; i++)
-            {
-                yield return returnSelector(
-                    ((object[])columns[0])[i].ChangeType<T1>(),
-                    ((object[])columns[1])[i].ChangeType<T2>(),
-                    ((object[])columns[2])[i].ChangeType<T3>(),
-                    ((object[])columns[3])[i].ChangeType<T4>(),
-                    ((object[])columns[4])[i].ChangeType<T5>(),
-                    ((object[])columns[5])[i].ChangeType<T6>(),
-                    ((object[])columns[6])[i].ChangeType<T7>(),
-                    ((object[])columns[7])[i].ChangeType<T8>(),
-                    ((object[])columns[8])[i].ChangeType<T9>(),
-                    ((object[])columns[9])[i].ChangeType<T10>(),
-                    ((object[])columns[10])[i].ChangeType<T11>(),
-                    ((object[])columns[11])[i].ChangeType<T12>());
-            }
+            return GetColumnsIterator(columns, rowCount, returnSelector);
         }
 
         /// <summary>
@@ -897,9 +688,11 @@
 		/// <param name="columnIndices">Array with the Columns Indexes.</param>
 		/// <param name="returnSelector">A function to map each column element to a return element.</param>
 		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
-		/// <exception cref="ArgumentOutOfRangeException">
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="columnIndices"/> or <paramref name="returnSelector"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
 		/// Number of columns doesn't match the number of returned members.
 		/// </exception>
+        /// <exception cref="InvalidOperationException">Thrown if the returned data is null, not in the expected format, or contains inconsistent row counts across columns.</exception>
         public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TReturn> returnSelector)
             where T1 : IConvertible
@@ -918,40 +711,13 @@
         {
             const int columnCount = 13;
 
-            if (columnIndices == null)
-            {
-                throw new ArgumentNullException(nameof(columnIndices));
-            }
+            ValidateGetColumnsArguments(columnIndices, columnCount, returnSelector);
 
-            if (returnSelector == null)
-            {
-                throw new ArgumentNullException(nameof(returnSelector));
-            }
+            object result = protocol.NotifyProtocol(321, tableId, columnIndices);
 
-            if (columnIndices.Length != columnCount)
-            {
-                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
-            }
+            ValidateResult(tableId, columnIndices, columnCount, result, out object[] columns, out int rowCount);
 
-            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
-
-            for (var i = 0; i < ((object[])columns[0]).Length; i++)
-            {
-                yield return returnSelector(
-                    ((object[])columns[0])[i].ChangeType<T1>(),
-                    ((object[])columns[1])[i].ChangeType<T2>(),
-                    ((object[])columns[2])[i].ChangeType<T3>(),
-                    ((object[])columns[3])[i].ChangeType<T4>(),
-                    ((object[])columns[4])[i].ChangeType<T5>(),
-                    ((object[])columns[5])[i].ChangeType<T6>(),
-                    ((object[])columns[6])[i].ChangeType<T7>(),
-                    ((object[])columns[7])[i].ChangeType<T8>(),
-                    ((object[])columns[8])[i].ChangeType<T9>(),
-                    ((object[])columns[9])[i].ChangeType<T10>(),
-                    ((object[])columns[10])[i].ChangeType<T11>(),
-                    ((object[])columns[11])[i].ChangeType<T12>(),
-                    ((object[])columns[12])[i].ChangeType<T13>());
-            }
+            return GetColumnsIterator(columns, rowCount, returnSelector);
         }
 
         /// <summary>
@@ -977,9 +743,11 @@
 		/// <param name="columnIndices">Array with the Columns Indexes.</param>
 		/// <param name="returnSelector">A function to map each column element to a return element.</param>
 		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
-		/// <exception cref="ArgumentOutOfRangeException">
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="columnIndices"/> or <paramref name="returnSelector"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
 		/// Number of columns doesn't match the number of returned members.
 		/// </exception>
+        /// <exception cref="InvalidOperationException">Thrown if the returned data is null, not in the expected format, or contains inconsistent row counts across columns.</exception>
         public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TReturn> returnSelector)
             where T1 : IConvertible
@@ -999,41 +767,13 @@
         {
             const int columnCount = 14;
 
-            if (columnIndices == null)
-            {
-                throw new ArgumentNullException(nameof(columnIndices));
-            }
+            ValidateGetColumnsArguments(columnIndices, columnCount, returnSelector);
 
-            if (returnSelector == null)
-            {
-                throw new ArgumentNullException(nameof(returnSelector));
-            }
+            object result = protocol.NotifyProtocol(321, tableId, columnIndices);
 
-            if (columnIndices.Length != columnCount)
-            {
-                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
-            }
+            ValidateResult(tableId, columnIndices, columnCount, result, out object[] columns, out int rowCount);
 
-            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
-
-            for (var i = 0; i < ((object[])columns[0]).Length; i++)
-            {
-                yield return returnSelector(
-                    ((object[])columns[0])[i].ChangeType<T1>(),
-                    ((object[])columns[1])[i].ChangeType<T2>(),
-                    ((object[])columns[2])[i].ChangeType<T3>(),
-                    ((object[])columns[3])[i].ChangeType<T4>(),
-                    ((object[])columns[4])[i].ChangeType<T5>(),
-                    ((object[])columns[5])[i].ChangeType<T6>(),
-                    ((object[])columns[6])[i].ChangeType<T7>(),
-                    ((object[])columns[7])[i].ChangeType<T8>(),
-                    ((object[])columns[8])[i].ChangeType<T9>(),
-                    ((object[])columns[9])[i].ChangeType<T10>(),
-                    ((object[])columns[10])[i].ChangeType<T11>(),
-                    ((object[])columns[11])[i].ChangeType<T12>(),
-                    ((object[])columns[12])[i].ChangeType<T13>(),
-                    ((object[])columns[13])[i].ChangeType<T14>());
-            }
+            return GetColumnsIterator(columns, rowCount, returnSelector);
         }
 
         /// <summary>
@@ -1060,9 +800,11 @@
 		/// <param name="columnIndices">Array with the Columns Indexes.</param>
 		/// <param name="returnSelector">A function to map each column element to a return element.</param>
 		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
-		/// <exception cref="ArgumentOutOfRangeException">
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="columnIndices"/> or <paramref name="returnSelector"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
 		/// Number of columns doesn't match the number of returned members.
 		/// </exception>
+        /// <exception cref="InvalidOperationException">Thrown if the returned data is null, not in the expected format, or contains inconsistent row counts across columns.</exception>
         public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TReturn> returnSelector)
             where T1 : IConvertible
@@ -1083,42 +825,13 @@
         {
             const int columnCount = 15;
 
-            if (columnIndices == null)
-            {
-                throw new ArgumentNullException(nameof(columnIndices));
-            }
+            ValidateGetColumnsArguments(columnIndices, columnCount, returnSelector);
 
-            if (returnSelector == null)
-            {
-                throw new ArgumentNullException(nameof(returnSelector));
-            }
+            object result = protocol.NotifyProtocol(321, tableId, columnIndices);
 
-            if (columnIndices.Length != columnCount)
-            {
-                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
-            }
+            ValidateResult(tableId, columnIndices, columnCount, result, out object[] columns, out int rowCount);
 
-            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
-
-            for (var i = 0; i < ((object[])columns[0]).Length; i++)
-            {
-                yield return returnSelector(
-                    ((object[])columns[0])[i].ChangeType<T1>(),
-                    ((object[])columns[1])[i].ChangeType<T2>(),
-                    ((object[])columns[2])[i].ChangeType<T3>(),
-                    ((object[])columns[3])[i].ChangeType<T4>(),
-                    ((object[])columns[4])[i].ChangeType<T5>(),
-                    ((object[])columns[5])[i].ChangeType<T6>(),
-                    ((object[])columns[6])[i].ChangeType<T7>(),
-                    ((object[])columns[7])[i].ChangeType<T8>(),
-                    ((object[])columns[8])[i].ChangeType<T9>(),
-                    ((object[])columns[9])[i].ChangeType<T10>(),
-                    ((object[])columns[10])[i].ChangeType<T11>(),
-                    ((object[])columns[11])[i].ChangeType<T12>(),
-                    ((object[])columns[12])[i].ChangeType<T13>(),
-                    ((object[])columns[13])[i].ChangeType<T14>(),
-                    ((object[])columns[14])[i].ChangeType<T15>());
-            }
+            return GetColumnsIterator(columns, rowCount, returnSelector);
         }
 
         /// <summary>
@@ -1146,9 +859,11 @@
 		/// <param name="columnIndices">Array with the Columns Indexes.</param>
 		/// <param name="returnSelector">A function to map each column element to a return element.</param>
 		/// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TReturn"/> with the desired columns.</returns>
-		/// <exception cref="ArgumentOutOfRangeException">
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="columnIndices"/> or <paramref name="returnSelector"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
 		/// Number of columns doesn't match the number of returned members.
 		/// </exception>
+        /// <exception cref="InvalidOperationException">Thrown if the returned data is null, not in the expected format, or contains inconsistent row counts across columns.</exception>
         public static IEnumerable<TReturn> GetColumns<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TReturn>(this SLProtocol protocol, int tableId, uint[] columnIndices,
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TReturn> returnSelector)
             where T1 : IConvertible
@@ -1170,43 +885,13 @@
         {
             const int columnCount = 16;
 
-            if (columnIndices == null)
-            {
-                throw new ArgumentNullException(nameof(columnIndices));
-            }
+            ValidateGetColumnsArguments(columnIndices, columnCount, returnSelector);
 
-            if (returnSelector == null)
-            {
-                throw new ArgumentNullException(nameof(returnSelector));
-            }
+            object result = protocol.NotifyProtocol(321, tableId, columnIndices);
 
-            if (columnIndices.Length != columnCount)
-            {
-                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
-            }
+            ValidateResult(tableId, columnIndices, columnCount, result, out object[] columns, out int rowCount);
 
-            var columns = (object[])protocol.NotifyProtocol(321, tableId, columnIndices);
-
-            for (var i = 0; i < ((object[])columns[0]).Length; i++)
-            {
-                yield return returnSelector(
-                    ((object[])columns[0])[i].ChangeType<T1>(),
-                    ((object[])columns[1])[i].ChangeType<T2>(),
-                    ((object[])columns[2])[i].ChangeType<T3>(),
-                    ((object[])columns[3])[i].ChangeType<T4>(),
-                    ((object[])columns[4])[i].ChangeType<T5>(),
-                    ((object[])columns[5])[i].ChangeType<T6>(),
-                    ((object[])columns[6])[i].ChangeType<T7>(),
-                    ((object[])columns[7])[i].ChangeType<T8>(),
-                    ((object[])columns[8])[i].ChangeType<T9>(),
-                    ((object[])columns[9])[i].ChangeType<T10>(),
-                    ((object[])columns[10])[i].ChangeType<T11>(),
-                    ((object[])columns[11])[i].ChangeType<T12>(),
-                    ((object[])columns[12])[i].ChangeType<T13>(),
-                    ((object[])columns[13])[i].ChangeType<T14>(),
-                    ((object[])columns[14])[i].ChangeType<T15>(),
-                    ((object[])columns[15])[i].ChangeType<T16>());
-            }
+            return GetColumnsIterator(columns, rowCount, returnSelector);
         }
 
         /// <summary>
@@ -1216,10 +901,15 @@
         /// <param name="protocol">Link with SLProtocol process.</param>
 		/// <param name="paramId">Id of the parameter to retrieve.</param>
 		/// <returns>The parameter value.</returns>
+        /// <exception cref="InvalidOperationException">Thrown if the returned value is null.</exception>
         public static T GetParameter<T>(this SLProtocol protocol, int paramId)
             where T : IConvertible
         {
-            return protocol.GetParameter(paramId).ChangeType<T>();
+            object value = protocol.GetParameter(paramId);
+
+            return value == null
+                ? throw new InvalidOperationException($"null was returned for parameter {paramId}. Does parameter with ID {paramId} exist?")
+                : value.ChangeType<T>();
         }
 
         /// <summary>
@@ -1235,123 +925,109 @@
 		/// <exception cref="ArgumentOutOfRangeException">
 		/// The length of <paramref name="paramIds"/> differs from the number of out parameters.
 		/// </exception>
+        /// <exception cref="InvalidOperationException">Thrown if the result is null, not in the expected format, or contains null values for any parameter.</exception>
         public static void GetParameters<T1, T2>(this SLProtocol protocol, uint[] paramIds, out T1 param1, out T2 param2)
             where T1 : IConvertible
             where T2 : IConvertible
         {
-            if (paramIds is null)
-            {
-                throw new ArgumentNullException(nameof(paramIds));
-            }
+            ValidateGetParametersArguments(paramIds, 2);
 
-            if (paramIds.Length != 2)
-            {
-                throw new ArgumentOutOfRangeException(nameof(paramIds), "paramIds need to have the same length as the number of out parameters");
-            }
+            var result = protocol.GetParameters(paramIds);
 
-            object[] parameters = (object[])protocol.GetParameters(paramIds);
+            ValidateResult(result, paramIds, out object[] parameters);
 
-            param1 = parameters[0].ChangeType<T1>();
-            param2 = parameters[1].ChangeType<T2>();
-        }
+			param1 = parameters[0].ChangeType<T1>();
+			param2 = parameters[1].ChangeType<T2>();
+		}
 
         /// <summary>
-		/// Gets the desired parameters and converts to the given types.
-		/// </summary>
-		/// <typeparam name="T1">Type of the fist parameter.</typeparam>
-		/// <typeparam name="T2">Type of the second parameter.</typeparam>
-		/// <typeparam name="T3">Type of the third parameter.</typeparam>
+        /// Gets the desired parameters and converts to the given types.
+        /// </summary>
+        /// <typeparam name="T1">Type of the fist parameter.</typeparam>
+        /// <typeparam name="T2">Type of the second parameter.</typeparam>
+        /// <typeparam name="T3">Type of the third parameter.</typeparam>
         /// <param name="protocol">Link with SLProtocol process.</param>
-		/// <param name="paramIds">Array with the ids of the Parameters to fetch.</param>
-		/// <param name="param1">Out variable with the first parameter value.</param>
-		/// <param name="param2">Out variable with the second parameter value.</param>
-		/// <param name="param3">Out variable with the third parameter value.</param>
-		/// <exception cref="ArgumentNullException"><paramref name="paramIds"/> is <see langword="null"/></exception>
-		/// <exception cref="ArgumentOutOfRangeException">
-		/// The length of <paramref name="paramIds"/> differs from the number of out parameters.
-		/// </exception>
+        /// <param name="paramIds">Array with the ids of the Parameters to fetch.</param>
+        /// <param name="param1">Out variable with the first parameter value.</param>
+        /// <param name="param2">Out variable with the second parameter value.</param>
+        /// <param name="param3">Out variable with the third parameter value.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="paramIds"/> is <see langword="null"/></exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The length of <paramref name="paramIds"/> differs from the number of out parameters.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Thrown if the result is null, not in the expected format, or contains null values for any parameter.</exception>
         public static void GetParameters<T1, T2, T3>(this SLProtocol protocol, uint[] paramIds, out T1 param1, out T2 param2, out T3 param3)
             where T1 : IConvertible
             where T2 : IConvertible
             where T3 : IConvertible
         {
-            if (paramIds is null)
-            {
-                throw new ArgumentNullException(nameof(paramIds));
-            }
+            ValidateGetParametersArguments(paramIds, 3);
 
-            if (paramIds.Length != 3)
-            {
-                throw new ArgumentOutOfRangeException(nameof(paramIds), "paramIds need to have the same length as the number of out parameters");
-            }
+            var result = protocol.GetParameters(paramIds);
 
-            object[] parameters = (object[])protocol.GetParameters(paramIds);
+            ValidateResult(result, paramIds, out object[] parameters);
 
             param1 = parameters[0].ChangeType<T1>();
-            param2 = parameters[1].ChangeType<T2>();
-            param3 = parameters[2].ChangeType<T3>();
-        }
+			param2 = parameters[1].ChangeType<T2>();
+			param3 = parameters[2].ChangeType<T3>();
+		}
 
         /// <summary>
-		/// Gets the desired parameters and converts to the given types.
-		/// </summary>
-		/// <typeparam name="T1">Type of the fist parameter.</typeparam>
-		/// <typeparam name="T2">Type of the second parameter.</typeparam>
-		/// <typeparam name="T3">Type of the third parameter.</typeparam>
-		/// <typeparam name="T4">Type of the fourth parameter.</typeparam>
+        /// Gets the desired parameters and converts to the given types.
+        /// </summary>
+        /// <typeparam name="T1">Type of the fist parameter.</typeparam>
+        /// <typeparam name="T2">Type of the second parameter.</typeparam>
+        /// <typeparam name="T3">Type of the third parameter.</typeparam>
+        /// <typeparam name="T4">Type of the fourth parameter.</typeparam>
         /// <param name="protocol">Link with SLProtocol process.</param>
-		/// <param name="paramIds">Array with the ids of the Parameters to fetch.</param>
-		/// <param name="param1">Out variable with the first parameter value.</param>
-		/// <param name="param2">Out variable with the second parameter value.</param>
-		/// <param name="param3">Out variable with the third parameter value.</param>
-		/// <param name="param4">Out variable with the fourth parameter value.</param>
-		/// <exception cref="ArgumentNullException"><paramref name="paramIds"/> is <see langword="null"/></exception>
-		/// <exception cref="ArgumentOutOfRangeException">
-		/// The length of <paramref name="paramIds"/> differs from the number of out parameters.
-		/// </exception>
+        /// <param name="paramIds">Array with the ids of the Parameters to fetch.</param>
+        /// <param name="param1">Out variable with the first parameter value.</param>
+        /// <param name="param2">Out variable with the second parameter value.</param>
+        /// <param name="param3">Out variable with the third parameter value.</param>
+        /// <param name="param4">Out variable with the fourth parameter value.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="paramIds"/> is <see langword="null"/></exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The length of <paramref name="paramIds"/> differs from the number of out parameters.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Thrown if the result is null, not in the expected format, or contains null values for any parameter.</exception>
         public static void GetParameters<T1, T2, T3, T4>(this SLProtocol protocol, uint[] paramIds, out T1 param1, out T2 param2, out T3 param3, out T4 param4)
             where T1 : IConvertible
             where T2 : IConvertible
             where T3 : IConvertible
             where T4 : IConvertible
         {
-            if (paramIds is null)
-            {
-                throw new ArgumentNullException(nameof(paramIds));
-            }
+            ValidateGetParametersArguments(paramIds, 4);
 
-            if (paramIds.Length != 4)
-            {
-                throw new ArgumentOutOfRangeException(nameof(paramIds), "paramIds need to have the same length as the number of out parameters");
-            }
+            var result = protocol.GetParameters(paramIds);
 
-            object[] parameters = (object[])protocol.GetParameters(paramIds);
+            ValidateResult(result, paramIds, out object[] parameters);
 
             param1 = parameters[0].ChangeType<T1>();
-            param2 = parameters[1].ChangeType<T2>();
-            param3 = parameters[2].ChangeType<T3>();
-            param4 = parameters[3].ChangeType<T4>();
-        }
+			param2 = parameters[1].ChangeType<T2>();
+			param3 = parameters[2].ChangeType<T3>();
+			param4 = parameters[3].ChangeType<T4>();
+		}
 
         /// <summary>
-		/// Gets the desired parameters and converts to the given types.
-		/// </summary>
-		/// <typeparam name="T1">Type of the fist parameter.</typeparam>
-		/// <typeparam name="T2">Type of the second parameter.</typeparam>
-		/// <typeparam name="T3">Type of the third parameter.</typeparam>
-		/// <typeparam name="T4">Type of the fourth parameter.</typeparam>
-		/// <typeparam name="T5">Type of the fifth parameter.</typeparam>
+        /// Gets the desired parameters and converts to the given types.
+        /// </summary>
+        /// <typeparam name="T1">Type of the fist parameter.</typeparam>
+        /// <typeparam name="T2">Type of the second parameter.</typeparam>
+        /// <typeparam name="T3">Type of the third parameter.</typeparam>
+        /// <typeparam name="T4">Type of the fourth parameter.</typeparam>
+        /// <typeparam name="T5">Type of the fifth parameter.</typeparam>
         /// <param name="protocol">Link with SLProtocol process.</param>
-		/// <param name="paramIds">Array with the ids of the Parameters to fetch.</param>
-		/// <param name="param1">Out variable with the first parameter value.</param>
-		/// <param name="param2">Out variable with the second parameter value.</param>
-		/// <param name="param3">Out variable with the third parameter value.</param>
-		/// <param name="param4">Out variable with the fourth parameter value.</param>
-		/// <param name="param5">Out variable with the fifth parameter value.</param>
-		/// <exception cref="ArgumentNullException"><paramref name="paramIds"/> is <see langword="null"/></exception>
-		/// <exception cref="ArgumentOutOfRangeException">
-		/// The length of <paramref name="paramIds"/> differs from the number of out parameters.
-		/// </exception>
+        /// <param name="paramIds">Array with the ids of the Parameters to fetch.</param>
+        /// <param name="param1">Out variable with the first parameter value.</param>
+        /// <param name="param2">Out variable with the second parameter value.</param>
+        /// <param name="param3">Out variable with the third parameter value.</param>
+        /// <param name="param4">Out variable with the fourth parameter value.</param>
+        /// <param name="param5">Out variable with the fifth parameter value.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="paramIds"/> is <see langword="null"/></exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The length of <paramref name="paramIds"/> differs from the number of out parameters.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Thrown if the result is null, not in the expected format, or contains null values for any parameter.</exception>
         public static void GetParameters<T1, T2, T3, T4, T5>(this SLProtocol protocol, uint[] paramIds, out T1 param1, out T2 param2, out T3 param3, out T4 param4, out T5 param5)
             where T1 : IConvertible
             where T2 : IConvertible
@@ -1359,46 +1035,41 @@
             where T4 : IConvertible
             where T5 : IConvertible
         {
-            if (paramIds is null)
-            {
-                throw new ArgumentNullException(nameof(paramIds));
-            }
+            ValidateGetParametersArguments(paramIds, 5);
 
-            if (paramIds.Length != 5)
-            {
-                throw new ArgumentOutOfRangeException(nameof(paramIds), "paramIds need to have the same length as the number of out parameters");
-            }
+            var result = protocol.GetParameters(paramIds);
 
-            object[] parameters = (object[])protocol.GetParameters(paramIds);
+            ValidateResult(result, paramIds, out object[] parameters);
 
-            param1 = parameters[0].ChangeType<T1>();
-            param2 = parameters[1].ChangeType<T2>();
-            param3 = parameters[2].ChangeType<T3>();
-            param4 = parameters[3].ChangeType<T4>();
-            param5 = parameters[4].ChangeType<T5>();
-        }
+			param1 = parameters[0].ChangeType<T1>();
+			param2 = parameters[1].ChangeType<T2>();
+			param3 = parameters[2].ChangeType<T3>();
+			param4 = parameters[3].ChangeType<T4>();
+			param5 = parameters[4].ChangeType<T5>();
+		}
 
         /// <summary>
-		/// Gets the desired parameters and converts to the given types.
-		/// </summary>
-		/// <typeparam name="T1">Type of the fist parameter.</typeparam>
-		/// <typeparam name="T2">Type of the second parameter.</typeparam>
-		/// <typeparam name="T3">Type of the third parameter.</typeparam>
-		/// <typeparam name="T4">Type of the fourth parameter.</typeparam>
-		/// <typeparam name="T5">Type of the fifth parameter.</typeparam>
-		/// <typeparam name="T6">Type of the sixth parameter.</typeparam>
+        /// Gets the desired parameters and converts to the given types.
+        /// </summary>
+        /// <typeparam name="T1">Type of the fist parameter.</typeparam>
+        /// <typeparam name="T2">Type of the second parameter.</typeparam>
+        /// <typeparam name="T3">Type of the third parameter.</typeparam>
+        /// <typeparam name="T4">Type of the fourth parameter.</typeparam>
+        /// <typeparam name="T5">Type of the fifth parameter.</typeparam>
+        /// <typeparam name="T6">Type of the sixth parameter.</typeparam>
         /// <param name="protocol">Link with SLProtocol process.</param>
-		/// <param name="paramIds">Array with the ids of the Parameters to fetch.</param>
-		/// <param name="param1">Out variable with the first parameter value.</param>
-		/// <param name="param2">Out variable with the second parameter value.</param>
-		/// <param name="param3">Out variable with the third parameter value.</param>
-		/// <param name="param4">Out variable with the fourth parameter value.</param>
-		/// <param name="param5">Out variable with the fifth parameter value.</param>
-		/// <param name="param6">Out variable with the sixth parameter value.</param>
-		/// <exception cref="ArgumentNullException"><paramref name="paramIds"/> is <see langword="null"/></exception>
-		/// <exception cref="ArgumentOutOfRangeException">
-		/// The length of <paramref name="paramIds"/> differs from the number of out parameters.
-		/// </exception>
+        /// <param name="paramIds">Array with the ids of the Parameters to fetch.</param>
+        /// <param name="param1">Out variable with the first parameter value.</param>
+        /// <param name="param2">Out variable with the second parameter value.</param>
+        /// <param name="param3">Out variable with the third parameter value.</param>
+        /// <param name="param4">Out variable with the fourth parameter value.</param>
+        /// <param name="param5">Out variable with the fifth parameter value.</param>
+        /// <param name="param6">Out variable with the sixth parameter value.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="paramIds"/> is <see langword="null"/></exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The length of <paramref name="paramIds"/> differs from the number of out parameters.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Thrown if the result is null, not in the expected format, or contains null values for any parameter.</exception>
         public static void GetParameters<T1, T2, T3, T4, T5, T6>(this SLProtocol protocol, uint[] paramIds, out T1 param1, out T2 param2, out T3 param3, out T4 param4, out T5 param5, out T6 param6)
             where T1 : IConvertible
             where T2 : IConvertible
@@ -1407,49 +1078,44 @@
             where T5 : IConvertible
             where T6 : IConvertible
         {
-            if (paramIds is null)
-            {
-                throw new ArgumentNullException(nameof(paramIds));
-            }
+            ValidateGetParametersArguments(paramIds, 6);
 
-            if (paramIds.Length != 6)
-            {
-                throw new ArgumentOutOfRangeException(nameof(paramIds), "paramIds need to have the same length as the number of out parameters");
-            }
+            var result = protocol.GetParameters(paramIds);
 
-            object[] parameters = (object[])protocol.GetParameters(paramIds);
+            ValidateResult(result, paramIds, out object[] parameters);
 
-            param1 = parameters[0].ChangeType<T1>();
-            param2 = parameters[1].ChangeType<T2>();
-            param3 = parameters[2].ChangeType<T3>();
-            param4 = parameters[3].ChangeType<T4>();
-            param5 = parameters[4].ChangeType<T5>();
-            param6 = parameters[5].ChangeType<T6>();
-        }
+			param1 = parameters[0].ChangeType<T1>();
+			param2 = parameters[1].ChangeType<T2>();
+			param3 = parameters[2].ChangeType<T3>();
+			param4 = parameters[3].ChangeType<T4>();
+			param5 = parameters[4].ChangeType<T5>();
+			param6 = parameters[5].ChangeType<T6>();
+		}
 
         /// <summary>
-		/// Gets the desired parameters and converts to the given types.
-		/// </summary>
-		/// <typeparam name="T1">Type of the fist parameter.</typeparam>
-		/// <typeparam name="T2">Type of the second parameter.</typeparam>
-		/// <typeparam name="T3">Type of the third parameter.</typeparam>
-		/// <typeparam name="T4">Type of the fourth parameter.</typeparam>
-		/// <typeparam name="T5">Type of the fifth parameter.</typeparam>
-		/// <typeparam name="T6">Type of the sixth parameter.</typeparam>
-		/// <typeparam name="T7">Type of the seventh parameter.</typeparam>
+        /// Gets the desired parameters and converts to the given types.
+        /// </summary>
+        /// <typeparam name="T1">Type of the fist parameter.</typeparam>
+        /// <typeparam name="T2">Type of the second parameter.</typeparam>
+        /// <typeparam name="T3">Type of the third parameter.</typeparam>
+        /// <typeparam name="T4">Type of the fourth parameter.</typeparam>
+        /// <typeparam name="T5">Type of the fifth parameter.</typeparam>
+        /// <typeparam name="T6">Type of the sixth parameter.</typeparam>
+        /// <typeparam name="T7">Type of the seventh parameter.</typeparam>
         /// <param name="protocol">Link with SLProtocol process.</param>
-		/// <param name="paramIds">Array with the ids of the Parameters to fetch.</param>
-		/// <param name="param1">Out variable with the first parameter value.</param>
-		/// <param name="param2">Out variable with the second parameter value.</param>
-		/// <param name="param3">Out variable with the third parameter value.</param>
-		/// <param name="param4">Out variable with the fourth parameter value.</param>
-		/// <param name="param5">Out variable with the fifth parameter value.</param>
-		/// <param name="param6">Out variable with the sixth parameter value.</param>
-		/// <param name="param7">Out variable with the seventh parameter value.</param>
-		/// <exception cref="ArgumentNullException"><paramref name="paramIds"/> is <see langword="null"/></exception>
-		/// <exception cref="ArgumentOutOfRangeException">
-		/// The length of <paramref name="paramIds"/> differs from the number of out parameters.
-		/// </exception>
+        /// <param name="paramIds">Array with the ids of the Parameters to fetch.</param>
+        /// <param name="param1">Out variable with the first parameter value.</param>
+        /// <param name="param2">Out variable with the second parameter value.</param>
+        /// <param name="param3">Out variable with the third parameter value.</param>
+        /// <param name="param4">Out variable with the fourth parameter value.</param>
+        /// <param name="param5">Out variable with the fifth parameter value.</param>
+        /// <param name="param6">Out variable with the sixth parameter value.</param>
+        /// <param name="param7">Out variable with the seventh parameter value.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="paramIds"/> is <see langword="null"/></exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The length of <paramref name="paramIds"/> differs from the number of out parameters.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Thrown if the result is null, not in the expected format, or contains null values for any parameter.</exception>
         public static void GetParameters<T1, T2, T3, T4, T5, T6, T7>(
             this SLProtocol protocol,
             uint[] paramIds,
@@ -1468,52 +1134,47 @@
             where T6 : IConvertible
             where T7 : IConvertible
         {
-            if (paramIds is null)
-            {
-                throw new ArgumentNullException(nameof(paramIds));
-            }
+            ValidateGetParametersArguments(paramIds, 7);
 
-            if (paramIds.Length != 7)
-            {
-                throw new ArgumentOutOfRangeException(nameof(paramIds), "paramIds need to have the same length as the number of out parameters");
-            }
+            var result = protocol.GetParameters(paramIds);
 
-            object[] parameters = (object[])protocol.GetParameters(paramIds);
+            ValidateResult(result, paramIds, out object[] parameters);
 
-            param1 = parameters[0].ChangeType<T1>();
-            param2 = parameters[1].ChangeType<T2>();
-            param3 = parameters[2].ChangeType<T3>();
-            param4 = parameters[3].ChangeType<T4>();
-            param5 = parameters[4].ChangeType<T5>();
-            param6 = parameters[5].ChangeType<T6>();
-            param7 = parameters[6].ChangeType<T7>();
-        }
+			param1 = parameters[0].ChangeType<T1>();
+			param2 = parameters[1].ChangeType<T2>();
+			param3 = parameters[2].ChangeType<T3>();
+			param4 = parameters[3].ChangeType<T4>();
+			param5 = parameters[4].ChangeType<T5>();
+			param6 = parameters[5].ChangeType<T6>();
+			param7 = parameters[6].ChangeType<T7>();
+		}
 
         /// <summary>
-		/// Gets the desired parameters and converts to the given types.
-		/// </summary>
-		/// <typeparam name="T1">Type of the fist parameter.</typeparam>
-		/// <typeparam name="T2">Type of the second parameter.</typeparam>
-		/// <typeparam name="T3">Type of the third parameter.</typeparam>
-		/// <typeparam name="T4">Type of the fourth parameter.</typeparam>
-		/// <typeparam name="T5">Type of the fifth parameter.</typeparam>
-		/// <typeparam name="T6">Type of the sixth parameter.</typeparam>
-		/// <typeparam name="T7">Type of the seventh parameter.</typeparam>
-		/// <typeparam name="T8">Type of the eighth parameter.</typeparam>
+        /// Gets the desired parameters and converts to the given types.
+        /// </summary>
+        /// <typeparam name="T1">Type of the fist parameter.</typeparam>
+        /// <typeparam name="T2">Type of the second parameter.</typeparam>
+        /// <typeparam name="T3">Type of the third parameter.</typeparam>
+        /// <typeparam name="T4">Type of the fourth parameter.</typeparam>
+        /// <typeparam name="T5">Type of the fifth parameter.</typeparam>
+        /// <typeparam name="T6">Type of the sixth parameter.</typeparam>
+        /// <typeparam name="T7">Type of the seventh parameter.</typeparam>
+        /// <typeparam name="T8">Type of the eighth parameter.</typeparam>
         /// <param name="protocol">Link with SLProtocol process.</param>
-		/// <param name="paramIds">Array with the ids of the Parameters to fetch.</param>
-		/// <param name="param1">Out variable with the first parameter value.</param>
-		/// <param name="param2">Out variable with the second parameter value.</param>
-		/// <param name="param3">Out variable with the third parameter value.</param>
-		/// <param name="param4">Out variable with the fourth parameter value.</param>
-		/// <param name="param5">Out variable with the fifth parameter value.</param>
-		/// <param name="param6">Out variable with the sixth parameter value.</param>
-		/// <param name="param7">Out variable with the seventh parameter value.</param>
-		/// <param name="param8">Out variable with the eighth parameter value.</param>
-		/// <exception cref="ArgumentNullException"><paramref name="paramIds"/> is <see langword="null"/></exception>
-		/// <exception cref="ArgumentOutOfRangeException">
-		/// The length of <paramref name="paramIds"/> differs from the number of out parameters.
-		/// </exception>
+        /// <param name="paramIds">Array with the ids of the Parameters to fetch.</param>
+        /// <param name="param1">Out variable with the first parameter value.</param>
+        /// <param name="param2">Out variable with the second parameter value.</param>
+        /// <param name="param3">Out variable with the third parameter value.</param>
+        /// <param name="param4">Out variable with the fourth parameter value.</param>
+        /// <param name="param5">Out variable with the fifth parameter value.</param>
+        /// <param name="param6">Out variable with the sixth parameter value.</param>
+        /// <param name="param7">Out variable with the seventh parameter value.</param>
+        /// <param name="param8">Out variable with the eighth parameter value.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="paramIds"/> is <see langword="null"/></exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The length of <paramref name="paramIds"/> differs from the number of out parameters.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Thrown if the result is null, not in the expected format, or contains null values for any parameter.</exception>
         public static void GetParameters<T1, T2, T3, T4, T5, T6, T7, T8>(
             this SLProtocol protocol,
             uint[] paramIds,
@@ -1534,55 +1195,50 @@
             where T7 : IConvertible
             where T8 : IConvertible
         {
-            if (paramIds is null)
-            {
-                throw new ArgumentNullException(nameof(paramIds));
-            }
+            ValidateGetParametersArguments(paramIds, 8);
 
-            if (paramIds.Length != 8)
-            {
-                throw new ArgumentOutOfRangeException(nameof(paramIds), "paramIds need to have the same length as the number of out parameters");
-            }
+            var result = protocol.GetParameters(paramIds);
 
-            object[] parameters = (object[])protocol.GetParameters(paramIds);
+            ValidateResult(result, paramIds, out object[] parameters);
 
-            param1 = parameters[0].ChangeType<T1>();
-            param2 = parameters[1].ChangeType<T2>();
-            param3 = parameters[2].ChangeType<T3>();
-            param4 = parameters[3].ChangeType<T4>();
-            param5 = parameters[4].ChangeType<T5>();
-            param6 = parameters[5].ChangeType<T6>();
-            param7 = parameters[6].ChangeType<T7>();
-            param8 = parameters[7].ChangeType<T8>();
-        }
+			param1 = parameters[0].ChangeType<T1>();
+			param2 = parameters[1].ChangeType<T2>();
+			param3 = parameters[2].ChangeType<T3>();
+			param4 = parameters[3].ChangeType<T4>();
+			param5 = parameters[4].ChangeType<T5>();
+			param6 = parameters[5].ChangeType<T6>();
+			param7 = parameters[6].ChangeType<T7>();
+			param8 = parameters[7].ChangeType<T8>();
+		}
 
         /// <summary>
-		/// Gets the desired parameters and converts to the given types.
-		/// </summary>
-		/// <typeparam name="T1">Type of the fist parameter.</typeparam>
-		/// <typeparam name="T2">Type of the second parameter.</typeparam>
-		/// <typeparam name="T3">Type of the third parameter.</typeparam>
-		/// <typeparam name="T4">Type of the fourth parameter.</typeparam>
-		/// <typeparam name="T5">Type of the fifth parameter.</typeparam>
-		/// <typeparam name="T6">Type of the sixth parameter.</typeparam>
-		/// <typeparam name="T7">Type of the seventh parameter.</typeparam>
-		/// <typeparam name="T8">Type of the eighth parameter.</typeparam>
-		/// <typeparam name="T9">Type of the ninth parameter.</typeparam>
+        /// Gets the desired parameters and converts to the given types.
+        /// </summary>
+        /// <typeparam name="T1">Type of the fist parameter.</typeparam>
+        /// <typeparam name="T2">Type of the second parameter.</typeparam>
+        /// <typeparam name="T3">Type of the third parameter.</typeparam>
+        /// <typeparam name="T4">Type of the fourth parameter.</typeparam>
+        /// <typeparam name="T5">Type of the fifth parameter.</typeparam>
+        /// <typeparam name="T6">Type of the sixth parameter.</typeparam>
+        /// <typeparam name="T7">Type of the seventh parameter.</typeparam>
+        /// <typeparam name="T8">Type of the eighth parameter.</typeparam>
+        /// <typeparam name="T9">Type of the ninth parameter.</typeparam>
         /// <param name="protocol">Link with SLProtocol process.</param>
-		/// <param name="paramIds">Array with the ids of the Parameters to fetch.</param>
-		/// <param name="param1">Out variable with the first parameter value.</param>
-		/// <param name="param2">Out variable with the second parameter value.</param>
-		/// <param name="param3">Out variable with the third parameter value.</param>
-		/// <param name="param4">Out variable with the fourth parameter value.</param>
-		/// <param name="param5">Out variable with the fifth parameter value.</param>
-		/// <param name="param6">Out variable with the sixth parameter value.</param>
-		/// <param name="param7">Out variable with the seventh parameter value.</param>
-		/// <param name="param8">Out variable with the eighth parameter value.</param>
-		/// <param name="param9">Out variable with the ninth parameter value.</param>
+        /// <param name="paramIds">Array with the ids of the Parameters to fetch.</param>
+        /// <param name="param1">Out variable with the first parameter value.</param>
+        /// <param name="param2">Out variable with the second parameter value.</param>
+        /// <param name="param3">Out variable with the third parameter value.</param>
+        /// <param name="param4">Out variable with the fourth parameter value.</param>
+        /// <param name="param5">Out variable with the fifth parameter value.</param>
+        /// <param name="param6">Out variable with the sixth parameter value.</param>
+        /// <param name="param7">Out variable with the seventh parameter value.</param>
+        /// <param name="param8">Out variable with the eighth parameter value.</param>
+        /// <param name="param9">Out variable with the ninth parameter value.</param>
         /// <exception cref="ArgumentNullException"><paramref name="paramIds"/> is <see langword="null"/></exception>
-		/// <exception cref="ArgumentOutOfRangeException">
-		/// The length of <paramref name="paramIds"/> differs from the number of out parameters.
-		/// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The length of <paramref name="paramIds"/> differs from the number of out parameters.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Thrown if the result is null, not in the expected format, or contains null values for any parameter.</exception>
         public static void GetParameters<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
             this SLProtocol protocol,
             uint[] paramIds,
@@ -1605,56 +1261,52 @@
             where T8 : IConvertible
             where T9 : IConvertible
         {
-            if (paramIds is null)
-            {
-                throw new ArgumentNullException(nameof(paramIds));
-            }
+            ValidateGetParametersArguments(paramIds, 9);
 
-            if (paramIds.Length != 9)
-            {
-                throw new ArgumentOutOfRangeException(nameof(paramIds), "paramIds need to have the same length as the number of out parameters");
-            }
+            var result = protocol.GetParameters(paramIds);
 
-            object[] parameters = (object[])protocol.GetParameters(paramIds);
+            ValidateResult(result, paramIds, out object[] parameters);
 
-            param1 = parameters[0].ChangeType<T1>();
-            param2 = parameters[1].ChangeType<T2>();
-            param3 = parameters[2].ChangeType<T3>();
-            param4 = parameters[3].ChangeType<T4>();
-            param5 = parameters[4].ChangeType<T5>();
-            param6 = parameters[5].ChangeType<T6>();
-            param7 = parameters[6].ChangeType<T7>();
-            param8 = parameters[7].ChangeType<T8>();
-            param9 = parameters[8].ChangeType<T9>();
-        }
+			param1 = parameters[0].ChangeType<T1>();
+			param2 = parameters[1].ChangeType<T2>();
+			param3 = parameters[2].ChangeType<T3>();
+			param4 = parameters[3].ChangeType<T4>();
+			param5 = parameters[4].ChangeType<T5>();
+			param6 = parameters[5].ChangeType<T6>();
+			param7 = parameters[6].ChangeType<T7>();
+			param8 = parameters[7].ChangeType<T8>();
+			param9 = parameters[8].ChangeType<T9>();
+		}
 
         /// <summary>
-		/// Gets the desired parameters and converts to the given types.
-		/// </summary>
-		/// <typeparam name="T1">Type of the fist parameter.</typeparam>
-		/// <typeparam name="T2">Type of the second parameter.</typeparam>
-		/// <typeparam name="T3">Type of the third parameter.</typeparam>
-		/// <typeparam name="T4">Type of the fourth parameter.</typeparam>
-		/// <typeparam name="T5">Type of the fifth parameter.</typeparam>
-		/// <typeparam name="T6">Type of the sixth parameter.</typeparam>
-		/// <typeparam name="T7">Type of the seventh parameter.</typeparam>
-		/// <typeparam name="T8">Type of the eighth parameter.</typeparam>
-		/// <typeparam name="T9">Type of the ninth parameter.</typeparam>
-		/// <typeparam name="T10">Type of the tenth parameter.</typeparam>
-		/// <param name="paramIds">Array with the ids of the Parameters to fetch.</param>
-		/// <param name="param1">Out variable with the first parameter value.</param>
-		/// <param name="param2">Out variable with the second parameter value.</param>
-		/// <param name="param3">Out variable with the third parameter value.</param>
-		/// <param name="param4">Out variable with the fourth parameter value.</param>
-		/// <param name="param5">Out variable with the fifth parameter value.</param>
-		/// <param name="param6">Out variable with the sixth parameter value.</param>
-		/// <param name="param7">Out variable with the seventh parameter value.</param>
-		/// <param name="param8">Out variable with the eighth parameter value.</param>
-		/// <param name="param9">Out variable with the ninth parameter value.</param>
-		/// <param name="param10">Out variable with the tenth parameter value.</param>
-		/// <exception cref="ArgumentOutOfRangeException">
-		/// If the length of the paramIds is different from the number of out parameters.
-		/// </exception>
+        /// Gets the desired parameters and converts to the given types.
+        /// </summary>
+        /// <typeparam name="T1">Type of the fist parameter.</typeparam>
+        /// <typeparam name="T2">Type of the second parameter.</typeparam>
+        /// <typeparam name="T3">Type of the third parameter.</typeparam>
+        /// <typeparam name="T4">Type of the fourth parameter.</typeparam>
+        /// <typeparam name="T5">Type of the fifth parameter.</typeparam>
+        /// <typeparam name="T6">Type of the sixth parameter.</typeparam>
+        /// <typeparam name="T7">Type of the seventh parameter.</typeparam>
+        /// <typeparam name="T8">Type of the eighth parameter.</typeparam>
+        /// <typeparam name="T9">Type of the ninth parameter.</typeparam>
+        /// <typeparam name="T10">Type of the tenth parameter.</typeparam>
+        /// <param name="protocol">Link with SLProtocol process.</param>
+        /// <param name="paramIds">Array with the ids of the Parameters to fetch.</param>
+        /// <param name="param1">Out variable with the first parameter value.</param>
+        /// <param name="param2">Out variable with the second parameter value.</param>
+        /// <param name="param3">Out variable with the third parameter value.</param>
+        /// <param name="param4">Out variable with the fourth parameter value.</param>
+        /// <param name="param5">Out variable with the fifth parameter value.</param>
+        /// <param name="param6">Out variable with the sixth parameter value.</param>
+        /// <param name="param7">Out variable with the seventh parameter value.</param>
+        /// <param name="param8">Out variable with the eighth parameter value.</param>
+        /// <param name="param9">Out variable with the ninth parameter value.</param>
+        /// <param name="param10">Out variable with the tenth parameter value.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// If the length of the paramIds is different from the number of out parameters.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Thrown if the result is null, not in the expected format, or contains null values for any parameter.</exception>
         public static void GetParameters<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
             this SLProtocol protocol,
             uint[] paramIds,
@@ -1679,17 +1331,11 @@
             where T9 : IConvertible
             where T10 : IConvertible
         {
-            if (paramIds is null)
-            {
-                throw new ArgumentNullException(nameof(paramIds));
-            }
+            ValidateGetParametersArguments(paramIds, 10);
 
-            if (paramIds.Length != 10)
-            {
-                throw new ArgumentOutOfRangeException(nameof(paramIds), "paramIds need to have the same length as the number of out parameters");
-            }
+            var result = protocol.GetParameters(paramIds);
 
-            object[] parameters = (object[])protocol.GetParameters(paramIds);
+            ValidateResult(result, paramIds, out object[] parameters);
 
             param1 = parameters[0].ChangeType<T1>();
             param2 = parameters[1].ChangeType<T2>();
@@ -2008,6 +1654,540 @@
                 }
 
                 protocol.SetParameters(paramsToSet.Keys.ToArray(), paramsToSet.Values.ToArray(), historySetDates);
+            }
+        }
+
+        /// <summary>
+        /// Validates the arguments provided to a method that retrieves columns using the specified selector.
+        /// </summary>
+        /// <typeparam name="TSelector">The type of the selector used to process or return column data. Must be a reference type.</typeparam>
+        /// <param name="columnIndices">An array of column indices to be retrieved. The array must not be null and its length must match the
+        /// specified column count.</param>
+        /// <param name="columnCount">The expected number of columns to retrieve. Must be equal to the length of the column indices array.</param>
+        /// <param name="returnSelector">A selector instance used to process or return the column data. Must not be null.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="columnIndices"/> or <paramref name="returnSelector"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if the length of <paramref name="columnIndices"/> does not equal <paramref name="columnCount"/>.</exception>
+        private static void ValidateGetColumnsArguments<TSelector>(uint[] columnIndices, int columnCount, TSelector returnSelector) where TSelector : class
+        {
+            if (columnIndices == null)
+            {
+                throw new ArgumentNullException(nameof(columnIndices));
+            }
+
+            if (returnSelector == null)
+            {
+                throw new ArgumentNullException(nameof(returnSelector));
+            }
+
+            if (columnIndices.Length != columnCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(columnIndices), $"Number of columns has to be {columnCount}");
+            }
+        }
+
+        /// <summary>
+        /// Validates the arguments provided to a method that retrieves parameters using the specified parameter IDs.
+        /// </summary>
+        /// <param name="paramIds">An array of parameter IDs to be retrieved. The array must not be null and its length must match the expected number of parameters.</param>
+        /// <param name="expectedParamIdCount">The expected number of parameter IDs.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="paramIds"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if the length of <paramref name="paramIds"/> does not match the expected number of parameters.</exception>
+        private static void ValidateGetParametersArguments(uint[] paramIds, int expectedParamIdCount)
+        {
+            if (paramIds is null)
+            {
+                throw new ArgumentNullException(nameof(paramIds));
+            }
+
+            if (paramIds.Length != expectedParamIdCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(paramIds), "paramIds need to have the same length as the number of out parameters");
+            }
+        }
+
+        /// <summary>
+        /// Validates the result of a GetColumns call for the specified table and column indices, ensuring it is in the expected format and contains consistent row counts across columns.
+        /// </summary>
+        /// <param name="tableId">The ID of the table from which columns were retrieved.</param>
+        /// <param name="columnIndices">The indices of the columns that were retrieved.</param>
+        /// <param name="columnCount">The expected number of columns.</param>
+        /// <param name="result">The result object returned from the GetColumns call.</param>
+        /// <param name="columns">The array of columns extracted from the result object.</param>
+        /// <param name="rowCount">The number of rows in each column.</param>
+        /// <exception cref="InvalidOperationException">Thrown if the returned data is null, not in the expected format, or contains inconsistent row counts across columns.</exception>
+        private static void ValidateResult(int tableId, uint[] columnIndices, int columnCount, object result, out object[] columns, out int rowCount)
+        {
+            if (result == null)
+            {
+                throw new InvalidOperationException($"null was returned for table {tableId}.");
+            }
+
+            columns = result as object[];
+
+            if (columns == null)
+            {
+                throw new InvalidOperationException($"Unexpected result format when retrieving columns {String.Join(", ", columnIndices)} from table {tableId}. Expected an array of objects.");
+            }
+
+            if (columns.Length != columnCount)
+            {
+                throw new InvalidOperationException($"Unexpected result format when retrieving columns {String.Join(", ", columnIndices)} from table {tableId}. Expected {columnCount} columns.");
+            }
+
+            rowCount = -1;
+            for (int c = 0; c < columnCount; c++)
+            {
+                if (columns[c] == null)
+                {
+                    throw new InvalidOperationException($"Column at index {columnIndices[c]} from table {tableId} is null.");
+                }
+
+                if (!(columns[c] is object[] columnData))
+                {
+                    throw new InvalidOperationException($"Unexpected format for column at index {columnIndices[c]} from table {tableId}. Expected an array of objects.");
+                }
+
+                if (rowCount == -1)
+                {
+                    rowCount = columnData.Length;
+                }
+                else if (columnData.Length != rowCount)
+                {
+                    throw new InvalidOperationException($"Column at index {columnIndices[c]} from table {tableId} has {columnData.Length} rows, but {rowCount} were expected.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Validates the result of a GetParameters call for the specified parameter IDs, ensuring it is in the expected format and contains non-null values for each parameter.
+        /// </summary>
+        /// <param name="result">The result object returned from the GetParameters call.</param>
+        /// <param name="paramIds">The IDs of the parameters that were retrieved.</param>
+        /// <param name="parameters">The array of parameters extracted from the result object.</param>
+        /// <exception cref="InvalidOperationException">Thrown if the result is null, not in the expected format, or contains null values for any parameter.</exception>
+        private static void ValidateResult(object result, uint[] paramIds, out object[] parameters)
+        {
+            if (result == null)
+            {
+                throw new InvalidOperationException("null was returned.");
+            }
+
+            parameters = result as object[];
+
+            if (parameters == null)
+            {
+                throw new InvalidOperationException("Unexpected result format when retrieving parameters. Expected an array of objects.");
+            }
+
+            if (parameters.Length != paramIds.Length)
+            {
+                throw new InvalidOperationException($"Unexpected result format when retrieving parameters {String.Join(",", paramIds)}. Expected {paramIds.Length} parameters but only received {parameters.Length} values.");
+            }
+
+            for(int i = 0; i < paramIds.Length; i++)
+            {
+                if (parameters[i] == null)
+                {
+                    throw new InvalidOperationException($"Returned value for parameter {paramIds[i]} was null. Does the parameter exist?");
+                }
+            }
+        }
+
+        private static IEnumerable<T> GetColumnIterator<T>(object[] column, int rowCount) where T : IConvertible
+        {
+            for (var i = 0; i < rowCount; i++)
+            {
+                yield return column[i].ChangeType<T>();
+            }
+        }
+
+        private static IEnumerable<TReturn> GetColumnsIterator<T1, T2, TReturn>(object[] columns, int rowCount, Func<T1, T2, TReturn> returnSelector)
+            where T1 : IConvertible
+            where T2 : IConvertible
+        {
+            for (var i = 0; i < rowCount; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>());
+            }
+        }
+
+        private static IEnumerable<TReturn> GetColumnsIterator<T1, T2, T3, TReturn>(object[] columns, int rowCount, Func<T1, T2, T3, TReturn> returnSelector)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+        {
+            for (var i = 0; i < rowCount; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>(),
+                    ((object[])columns[2])[i].ChangeType<T3>());
+            }
+        }
+
+        private static IEnumerable<TReturn> GetColumnsIterator<T1, T2, T3, T4, TReturn>(object[] columns, int rowCount, Func<T1, T2, T3, T4, TReturn> returnSelector)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+        {
+            for (var i = 0; i < rowCount; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>(),
+                    ((object[])columns[2])[i].ChangeType<T3>(),
+                    ((object[])columns[3])[i].ChangeType<T4>());
+            }
+        }
+
+        private static IEnumerable<TReturn> GetColumnsIterator<T1, T2, T3, T4, T5, TReturn>(object[] columns, int rowCount, Func<T1, T2, T3, T4, T5, TReturn> returnSelector)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+        {
+            for (var i = 0; i < rowCount; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>(),
+                    ((object[])columns[2])[i].ChangeType<T3>(),
+                    ((object[])columns[3])[i].ChangeType<T4>(),
+                    ((object[])columns[4])[i].ChangeType<T5>());
+            }
+        }
+
+        private static IEnumerable<TReturn> GetColumnsIterator<T1, T2, T3, T4, T5, T6, TReturn>(object[] columns, int rowCount, Func<T1, T2, T3, T4, T5, T6, TReturn> returnSelector)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+            where T6 : IConvertible
+        {
+            for (var i = 0; i < rowCount; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>(),
+                    ((object[])columns[2])[i].ChangeType<T3>(),
+                    ((object[])columns[3])[i].ChangeType<T4>(),
+                    ((object[])columns[4])[i].ChangeType<T5>(),
+                    ((object[])columns[5])[i].ChangeType<T6>());
+            }
+        }
+
+        private static IEnumerable<TReturn> GetColumnsIterator<T1, T2, T3, T4, T5, T6, T7, TReturn>(object[] columns, int rowCount, Func<T1, T2, T3, T4, T5, T6, T7, TReturn> returnSelector)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+            where T6 : IConvertible
+            where T7 : IConvertible
+        {
+            for (var i = 0; i < rowCount; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>(),
+                    ((object[])columns[2])[i].ChangeType<T3>(),
+                    ((object[])columns[3])[i].ChangeType<T4>(),
+                    ((object[])columns[4])[i].ChangeType<T5>(),
+                    ((object[])columns[5])[i].ChangeType<T6>(),
+                    ((object[])columns[6])[i].ChangeType<T7>());
+            }
+        }
+
+        private static IEnumerable<TReturn> GetColumnsIterator<T1, T2, T3, T4, T5, T6, T7, T8, TReturn>(object[] columns, int rowCount, Func<T1, T2, T3, T4, T5, T6, T7, T8, TReturn> returnSelector)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+            where T6 : IConvertible
+            where T7 : IConvertible
+            where T8 : IConvertible
+        {
+            for (var i = 0; i < rowCount; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>(),
+                    ((object[])columns[2])[i].ChangeType<T3>(),
+                    ((object[])columns[3])[i].ChangeType<T4>(),
+                    ((object[])columns[4])[i].ChangeType<T5>(),
+                    ((object[])columns[5])[i].ChangeType<T6>(),
+                    ((object[])columns[6])[i].ChangeType<T7>(),
+                    ((object[])columns[7])[i].ChangeType<T8>());
+            }
+        }
+
+        private static IEnumerable<TReturn> GetColumnsIterator<T1, T2, T3, T4, T5, T6, T7, T8, T9, TReturn>(object[] columns, int rowCount, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TReturn> returnSelector)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+            where T6 : IConvertible
+            where T7 : IConvertible
+            where T8 : IConvertible
+            where T9 : IConvertible
+        {
+            for (var i = 0; i < rowCount; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>(),
+                    ((object[])columns[2])[i].ChangeType<T3>(),
+                    ((object[])columns[3])[i].ChangeType<T4>(),
+                    ((object[])columns[4])[i].ChangeType<T5>(),
+                    ((object[])columns[5])[i].ChangeType<T6>(),
+                    ((object[])columns[6])[i].ChangeType<T7>(),
+                    ((object[])columns[7])[i].ChangeType<T8>(),
+                    ((object[])columns[8])[i].ChangeType<T9>());
+            }
+        }
+
+        private static IEnumerable<TReturn> GetColumnsIterator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TReturn>(object[] columns, int rowCount, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TReturn> returnSelector)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+            where T6 : IConvertible
+            where T7 : IConvertible
+            where T8 : IConvertible
+            where T9 : IConvertible
+            where T10 : IConvertible
+        {
+            for (var i = 0; i < rowCount; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>(),
+                    ((object[])columns[2])[i].ChangeType<T3>(),
+                    ((object[])columns[3])[i].ChangeType<T4>(),
+                    ((object[])columns[4])[i].ChangeType<T5>(),
+                    ((object[])columns[5])[i].ChangeType<T6>(),
+                    ((object[])columns[6])[i].ChangeType<T7>(),
+                    ((object[])columns[7])[i].ChangeType<T8>(),
+                    ((object[])columns[8])[i].ChangeType<T9>(),
+                    ((object[])columns[9])[i].ChangeType<T10>());
+            }
+        }
+
+        private static IEnumerable<TReturn> GetColumnsIterator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TReturn>(object[] columns, int rowCount, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TReturn> returnSelector)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+            where T6 : IConvertible
+            where T7 : IConvertible
+            where T8 : IConvertible
+            where T9 : IConvertible
+            where T10 : IConvertible
+            where T11 : IConvertible
+        {
+            for (var i = 0; i < rowCount; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>(),
+                    ((object[])columns[2])[i].ChangeType<T3>(),
+                    ((object[])columns[3])[i].ChangeType<T4>(),
+                    ((object[])columns[4])[i].ChangeType<T5>(),
+                    ((object[])columns[5])[i].ChangeType<T6>(),
+                    ((object[])columns[6])[i].ChangeType<T7>(),
+                    ((object[])columns[7])[i].ChangeType<T8>(),
+                    ((object[])columns[8])[i].ChangeType<T9>(),
+                    ((object[])columns[9])[i].ChangeType<T10>(),
+                    ((object[])columns[10])[i].ChangeType<T11>());
+            }
+        }
+
+        private static IEnumerable<TReturn> GetColumnsIterator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TReturn>(object[] columns, int rowCount, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TReturn> returnSelector)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+            where T6 : IConvertible
+            where T7 : IConvertible
+            where T8 : IConvertible
+            where T9 : IConvertible
+            where T10 : IConvertible
+            where T11 : IConvertible
+            where T12 : IConvertible
+        {
+            for (var i = 0; i < rowCount; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>(),
+                    ((object[])columns[2])[i].ChangeType<T3>(),
+                    ((object[])columns[3])[i].ChangeType<T4>(),
+                    ((object[])columns[4])[i].ChangeType<T5>(),
+                    ((object[])columns[5])[i].ChangeType<T6>(),
+                    ((object[])columns[6])[i].ChangeType<T7>(),
+                    ((object[])columns[7])[i].ChangeType<T8>(),
+                    ((object[])columns[8])[i].ChangeType<T9>(),
+                    ((object[])columns[9])[i].ChangeType<T10>(),
+                    ((object[])columns[10])[i].ChangeType<T11>(),
+                    ((object[])columns[11])[i].ChangeType<T12>());
+            }
+        }
+
+        private static IEnumerable<TReturn> GetColumnsIterator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TReturn>(object[] columns, int rowCount, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TReturn> returnSelector)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+            where T6 : IConvertible
+            where T7 : IConvertible
+            where T8 : IConvertible
+            where T9 : IConvertible
+            where T10 : IConvertible
+            where T11 : IConvertible
+            where T12 : IConvertible
+            where T13 : IConvertible
+        {
+            for (var i = 0; i < rowCount; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>(),
+                    ((object[])columns[2])[i].ChangeType<T3>(),
+                    ((object[])columns[3])[i].ChangeType<T4>(),
+                    ((object[])columns[4])[i].ChangeType<T5>(),
+                    ((object[])columns[5])[i].ChangeType<T6>(),
+                    ((object[])columns[6])[i].ChangeType<T7>(),
+                    ((object[])columns[7])[i].ChangeType<T8>(),
+                    ((object[])columns[8])[i].ChangeType<T9>(),
+                    ((object[])columns[9])[i].ChangeType<T10>(),
+                    ((object[])columns[10])[i].ChangeType<T11>(),
+                    ((object[])columns[11])[i].ChangeType<T12>(),
+                    ((object[])columns[12])[i].ChangeType<T13>());
+            }
+        }
+
+        private static IEnumerable<TReturn> GetColumnsIterator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TReturn>(object[] columns, int rowCount, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TReturn> returnSelector)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+            where T6 : IConvertible
+            where T7 : IConvertible
+            where T8 : IConvertible
+            where T9 : IConvertible
+            where T10 : IConvertible
+            where T11 : IConvertible
+            where T12 : IConvertible
+            where T13 : IConvertible
+            where T14 : IConvertible
+        {
+            for (var i = 0; i < rowCount; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>(),
+                    ((object[])columns[2])[i].ChangeType<T3>(),
+                    ((object[])columns[3])[i].ChangeType<T4>(),
+                    ((object[])columns[4])[i].ChangeType<T5>(),
+                    ((object[])columns[5])[i].ChangeType<T6>(),
+                    ((object[])columns[6])[i].ChangeType<T7>(),
+                    ((object[])columns[7])[i].ChangeType<T8>(),
+                    ((object[])columns[8])[i].ChangeType<T9>(),
+                    ((object[])columns[9])[i].ChangeType<T10>(),
+                    ((object[])columns[10])[i].ChangeType<T11>(),
+                    ((object[])columns[11])[i].ChangeType<T12>(),
+                    ((object[])columns[12])[i].ChangeType<T13>(),
+                    ((object[])columns[13])[i].ChangeType<T14>());
+            }
+        }
+
+        private static IEnumerable<TReturn> GetColumnsIterator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TReturn>(object[] columns, int rowCount, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TReturn> returnSelector)
+            where T1 : IConvertible
+            where T2 : IConvertible
+            where T3 : IConvertible
+            where T4 : IConvertible
+            where T5 : IConvertible
+            where T6 : IConvertible
+            where T7 : IConvertible
+            where T8 : IConvertible
+            where T9 : IConvertible
+            where T10 : IConvertible
+            where T11 : IConvertible
+            where T12 : IConvertible
+            where T13 : IConvertible
+            where T14 : IConvertible
+            where T15 : IConvertible
+        {
+            for (var i = 0; i < rowCount; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>(),
+                    ((object[])columns[2])[i].ChangeType<T3>(),
+                    ((object[])columns[3])[i].ChangeType<T4>(),
+                    ((object[])columns[4])[i].ChangeType<T5>(),
+                    ((object[])columns[5])[i].ChangeType<T6>(),
+                    ((object[])columns[6])[i].ChangeType<T7>(),
+                    ((object[])columns[7])[i].ChangeType<T8>(),
+                    ((object[])columns[8])[i].ChangeType<T9>(),
+                    ((object[])columns[9])[i].ChangeType<T10>(),
+                    ((object[])columns[10])[i].ChangeType<T11>(),
+                    ((object[])columns[11])[i].ChangeType<T12>(),
+                    ((object[])columns[12])[i].ChangeType<T13>(),
+                    ((object[])columns[13])[i].ChangeType<T14>(),
+                    ((object[])columns[14])[i].ChangeType<T15>());
+            }
+        }
+
+        private static IEnumerable<TReturn> GetColumnsIterator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TReturn>(object[] columns, int rowCount, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TReturn> returnSelector)
+    where T1 : IConvertible
+    where T2 : IConvertible
+    where T3 : IConvertible
+    where T4 : IConvertible
+    where T5 : IConvertible
+    where T6 : IConvertible
+    where T7 : IConvertible
+    where T8 : IConvertible
+    where T9 : IConvertible
+    where T10 : IConvertible
+    where T11 : IConvertible
+    where T12 : IConvertible
+    where T13 : IConvertible
+    where T14 : IConvertible
+    where T15 : IConvertible
+    where T16 : IConvertible
+        {
+            for (var i = 0; i < rowCount; i++)
+            {
+                yield return returnSelector(
+                    ((object[])columns[0])[i].ChangeType<T1>(),
+                    ((object[])columns[1])[i].ChangeType<T2>(),
+                    ((object[])columns[2])[i].ChangeType<T3>(),
+                    ((object[])columns[3])[i].ChangeType<T4>(),
+                    ((object[])columns[4])[i].ChangeType<T5>(),
+                    ((object[])columns[5])[i].ChangeType<T6>(),
+                    ((object[])columns[6])[i].ChangeType<T7>(),
+                    ((object[])columns[7])[i].ChangeType<T8>(),
+                    ((object[])columns[8])[i].ChangeType<T9>(),
+                    ((object[])columns[9])[i].ChangeType<T10>(),
+                    ((object[])columns[10])[i].ChangeType<T11>(),
+                    ((object[])columns[11])[i].ChangeType<T12>(),
+                    ((object[])columns[12])[i].ChangeType<T13>(),
+                    ((object[])columns[13])[i].ChangeType<T14>(),
+                    ((object[])columns[14])[i].ChangeType<T15>(),
+                    ((object[])columns[15])[i].ChangeType<T16>());
             }
         }
     }

--- a/Utils.Protocol.Extension/TypeExtensions.cs
+++ b/Utils.Protocol.Extension/TypeExtensions.cs
@@ -3,9 +3,9 @@
     using System;
 
     /// <summary>
-	/// Defines extension methods to change a type of an object value.
-	/// </summary>
-	internal static class TypeExtensions
+    /// Defines extension methods to change a type of an object value.
+    /// </summary>
+    internal static class TypeExtensions
     {
         private static readonly Type DateTimeType = typeof(DateTime);
 

--- a/Utils.Protocol.Extension/TypeExtensions.cs
+++ b/Utils.Protocol.Extension/TypeExtensions.cs
@@ -1,0 +1,72 @@
+﻿namespace Skyline.DataMiner.Utils.Protocol.Extension
+{
+    using System;
+
+    /// <summary>
+	/// Defines extension methods to change a type of an object value.
+	/// </summary>
+	internal static class TypeExtensions
+    {
+        private static readonly Type DateTimeType = typeof(DateTime);
+
+        /// <summary>
+        /// Converts an object to the desired type.
+        /// </summary>
+        /// <typeparam name="T">Type of the result.</typeparam>
+        /// <param name="obj">Object to convert.</param>
+        /// <returns>The converted object.</returns>
+        /// <exception cref="InvalidCastException">This conversion is not supported. Or <paramref name="obj"/> does not implement the <see cref="IConvertible"/> interface.</exception>
+        /// <exception cref="FormatException"><paramref name="obj"/> is not in a format unrecognized by conversionType.</exception>
+        /// <exception cref="OverflowException"><paramref name="obj"/> represents a number that is out of the range of conversionType.</exception>
+        public static T ChangeType<T>(this object obj)
+            where T : IConvertible
+        {
+            if (obj == null)
+            {
+                return default(T);
+            }
+
+            var type = typeof(T);
+
+            if (type.IsEnum)
+            {
+                return (T)Enum.ToObject(type, obj.ChangeType<int>());
+            }
+
+            if (type == DateTimeType)
+            {
+                var oadate = Convert.ToDouble(obj);
+
+                if (!oadate.InRange(-657435.0, 2958465.99999999))
+                {
+                    throw new OverflowException($"{obj} is not a valid OA Date, supported range -657435.0 to 2958465.99999999");
+                }
+
+                object date = DateTime.FromOADate(oadate);
+                return (T)date;
+            }
+
+            return (T)Convert.ChangeType(obj, type);
+        }
+
+        /// <summary>
+        /// Checks if a values is inside an interval.
+        /// </summary>
+        /// <typeparam name="T">Type of the value.</typeparam>
+        /// <param name="value">Value to check.</param>
+        /// <param name="fromInclusive">Lower Range, inclusive value.</param>
+        /// <param name="toInclusive">High Range, inclusive value.</param>
+        /// <returns>True if the value is between the given interval; otherwise false.</returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="value"/> is null.</exception>
+        private static bool InRange<T>(this T value, T fromInclusive, T toInclusive)
+            where T : IComparable
+        {
+            if (Object.Equals(value, default(T)))
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            return value.CompareTo(fromInclusive) >= 0 && value.CompareTo(toInclusive) <= 0;
+        }
+    }
+}


### PR DESCRIPTION
These methods originate from the DataMinerSystem class library. As ILocalElement/ILocalTable has been marked obsolete in the [DataMinerSystem](https://www.nuget.org/packages/Skyline.DataMiner.Core.DataMinerSystem.Common) class library, this PR provides a way to still use these via this protocolExtensions NuGet.